### PR TITLE
feat: Apple Watch サポートの追加

### DIFF
--- a/BlackCat.xcodeproj/project.pbxproj
+++ b/BlackCat.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BCWATCH011B442929E4593 /* BlackCatWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH001C4F5793BE31B /* BlackCatWatchApp.swift */; };
+		BCWATCH01214E7882B14E5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH002779125FE75CF /* ContentView.swift */; };
+		BCWATCH0130478CB7770DC /* WatchDeliveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH003AEE26FF5EC46 /* WatchDeliveryViewModel.swift */; };
+		BCWATCH014A6F97A76425E /* WatchDeliveryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH0043573586FD0BE /* WatchDeliveryItem.swift */; };
+		BCWATCH015A3263D5BB6CD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BCWATCH0058C3446B79F39 /* Assets.xcassets */; };
+		BCWATCH0338061C1008830 /* SharedDeliveryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH03175D7F53C6170 /* SharedDeliveryItem.swift */; };
+		BCWATCH034A66BD580E85F /* SharedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH0321B1868BAB38B /* SharedDataManager.swift */; };
+		BCWATCH03599FA2E8BA070 /* SharedDeliveryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH03175D7F53C6170 /* SharedDeliveryItem.swift */; };
+		BCWATCH0369939F397947D /* SharedDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH0321B1868BAB38B /* SharedDataManager.swift */; };
+
 		19ABC02226D5500000000014 /* DeliveryShareContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC02326D5500000000015 /* DeliveryShareContent.swift */; };
 		19ABC02426D5500000000016 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC02526D5500000000017 /* ShareSheet.swift */; };
 		19ABC02626D5500000000018 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC02726D5500000000019 /* ConfettiView.swift */; };
@@ -75,6 +85,14 @@
 		2B5AC1FE2670EDAB00CB80F6 /* BlackCarWidget.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 2B5AC1F92670EDA400CB80F6 /* BlackCarWidget.intentdefinition */; };
 		2B5D54B826ED084100189351 /* View+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5D54B726ED084100189351 /* View+extension.swift */; };
 		19ABC02026D5500000000012 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19ABC01F26D5500000000012 /* SplashView.swift */; };
+		WCMGR001A1B2C3D4E5F6 /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = WCMGR002A1B2C3D4E5F6 /* WatchConnectivityManager.swift */; };
+		WDATA001A1B2C3D4E5F6 /* WatchDeliveryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = WDATA002A1B2C3D4E5F6 /* WatchDeliveryData.swift */; };
+		WDATA003A1B2C3D4E5F6 /* WatchDeliveryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = WDATA002A1B2C3D4E5F6 /* WatchDeliveryData.swift */; };
+		BCWATCH05A12345678901 /* WatchDeliveryListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH05B12345678901 /* WatchDeliveryListView.swift */; };
+		BCWATCH05C12345678901 /* WatchDeliveryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH05D12345678901 /* WatchDeliveryDetailView.swift */; };
+		BCWATCH05E12345678901 /* ComplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH05F12345678901 /* ComplicationController.swift */; };
+		BCWATCH06012345678901 /* WatchConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCWATCH06112345678901 /* WatchConnectivityManager.swift */; };
+		BCWATCH06212345678901 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BCWATCH06312345678901 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -195,7 +213,25 @@
 		2B5AC1FA2670EDAB00CB80F6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2B5AC1FC2670EDAB00CB80F6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2B5D54B726ED084100189351 /* View+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+extension.swift"; sourceTree = "<group>"; };
+		BCWATCH001C4F5793BE31B /* BlackCatWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlackCatWatchApp.swift; sourceTree = "<group>"; };
+		BCWATCH002779125FE75CF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BCWATCH003AEE26FF5EC46 /* WatchDeliveryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDeliveryViewModel.swift; sourceTree = "<group>"; };
+		BCWATCH0043573586FD0BE /* WatchDeliveryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDeliveryItem.swift; sourceTree = "<group>"; };
+		BCWATCH0058C3446B79F39 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BCWATCH006DDC961025C0A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BCWATCH04249CA04A97F01 /* BlackCatWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BlackCatWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BCWATCH03175D7F53C6170 /* SharedDeliveryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDeliveryItem.swift; sourceTree = "<group>"; };
+		BCWATCH0321B1868BAB38B /* SharedDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataManager.swift; sourceTree = "<group>"; };
+		WCMGR002A1B2C3D4E5F6 /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
+		WDATA002A1B2C3D4E5F6 /* WatchDeliveryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WatchDeliveryData.swift; path = Shared/WatchDeliveryData.swift; sourceTree = SOURCE_ROOT; };
+		BCWATCH05B12345678901 /* WatchDeliveryListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDeliveryListView.swift; sourceTree = "<group>"; };
+		BCWATCH05D12345678901 /* WatchDeliveryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchDeliveryDetailView.swift; sourceTree = "<group>"; };
+		BCWATCH05F12345678901 /* ComplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationController.swift; sourceTree = "<group>"; };
+		BCWATCH06112345678901 /* WatchConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityManager.swift; sourceTree = "<group>"; };
+		BCWATCH06312345678901 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		BCWATCH06412345678901 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
 
 /* Begin PBXFrameworksBuildPhase section */
 		197A43F229E137F700D111B2 /* Frameworks */ = {
@@ -237,7 +273,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BCWATCH0446D0F16032B15 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
+
 
 /* Begin PBXGroup section */
 		19334B9826C8185800840389 /* Resources */ = {
@@ -378,6 +422,7 @@
 				19ABC01226D550000000000A /* BackgroundRefreshManager.swift */,
 				19ABC01B26D550000000000F /* HapticManager.swift */,
 				19ABC02326D5500000000015 /* DeliveryShareContent.swift */,
+				WCMGR002A1B2C3D4E5F6 /* WatchConnectivityManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -404,6 +449,8 @@
 				19A9A2C326C1342E00BD5AF8 /* DomainTests */,
 				2B5AC1F12670EDA300CB80F6 /* Frameworks */,
 				2B5AC1DA2670EBAF00CB80F6 /* Products */,
+				BCWATCH02106BE1DE65B10 /* BlackCatWatch */,
+				BCWATCH0228A49BD09C96F /* Shared */,
 			);
 			sourceTree = "<group>";
 		};
@@ -415,6 +462,7 @@
 				19A9A2B526C1342E00BD5AF8 /* Domain.framework */,
 				19A9A2BD26C1342E00BD5AF8 /* DomainTests.xctest */,
 				197A43F529E137F800D111B2 /* BlackCatTests.xctest */,
+				BCWATCH04249CA04A97F01 /* BlackCatWatch.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -510,7 +558,61 @@
 			path = Splash;
 			sourceTree = "<group>";
 		};
+		BCWATCH02106BE1DE65B10 /* BlackCatWatch */ = {
+			isa = PBXGroup;
+			children = (
+				BCWATCH001C4F5793BE31B /* BlackCatWatchApp.swift */,
+				BCWATCH002779125FE75CF /* ContentView.swift */,
+				BCWATCH003AEE26FF5EC46 /* WatchDeliveryViewModel.swift */,
+				BCWATCH0043573586FD0BE /* WatchDeliveryItem.swift */,
+				BCWATCH07012345678901 /* Views */,
+				BCWATCH07112345678901 /* Complications */,
+				BCWATCH07212345678901 /* Utils */,
+				BCWATCH0058C3446B79F39 /* Assets.xcassets */,
+				BCWATCH006DDC961025C0A /* Info.plist */,
+			);
+			path = BlackCatWatch;
+			sourceTree = "<group>";
+		};
+		BCWATCH07012345678901 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				BCWATCH05B12345678901 /* WatchDeliveryListView.swift */,
+				BCWATCH05D12345678901 /* WatchDeliveryDetailView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		BCWATCH07112345678901 /* Complications */ = {
+			isa = PBXGroup;
+			children = (
+				BCWATCH05F12345678901 /* ComplicationController.swift */,
+				BCWATCH06312345678901 /* Assets.xcassets */,
+				BCWATCH06412345678901 /* Info.plist */,
+			);
+			path = Complications;
+			sourceTree = "<group>";
+		};
+		BCWATCH07212345678901 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				BCWATCH06112345678901 /* WatchConnectivityManager.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		BCWATCH0228A49BD09C96F /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				BCWATCH03175D7F53C6170 /* SharedDeliveryItem.swift */,
+				BCWATCH0321B1868BAB38B /* SharedDataManager.swift */,
+				WDATA002A1B2C3D4E5F6 /* WatchDeliveryData.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
 
 /* Begin PBXHeadersBuildPhase section */
 		19A9A2B026C1342E00BD5AF8 /* Headers */ = {
@@ -615,7 +717,25 @@
 			productReference = 2B5AC1F02670EDA300CB80F6 /* BlackCarWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		BCWATCH041A78B91429135 /* BlackCatWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCWATCH0460BC07372DDE1 /* Build configuration list for PBXNativeTarget "BlackCatWatch" */;
+			buildPhases = (
+				BCWATCH043BEED89F960F1 /* Sources */,
+				BCWATCH0446D0F16032B15 /* Frameworks */,
+				BCWATCH045760F1E941CF0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BlackCatWatch;
+			productName = BlackCatWatch;
+			productReference = BCWATCH04249CA04A97F01 /* BlackCatWatch.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
+
 
 /* Begin PBXProject section */
 		2B5AC1D12670EBAF00CB80F6 /* Project object */ = {
@@ -661,6 +781,7 @@
 				19A9A2B426C1342E00BD5AF8 /* Domain */,
 				19A9A2BC26C1342E00BD5AF8 /* DomainTests */,
 				197A43F429E137F700D111B2 /* BlackCatTests */,
+				BCWATCH041A78B91429135 /* BlackCatWatch */,
 			);
 		};
 /* End PBXProject section */
@@ -705,7 +826,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BCWATCH045760F1E941CF0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCWATCH015A3263D5BB6CD /* Assets.xcassets in Resources */,
+				BCWATCH06212345678901 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
+
 
 /* Begin PBXSourcesBuildPhase section */
 		197A43F129E137F700D111B2 /* Sources */ = {
@@ -789,6 +920,10 @@
 				19ABC02226D5500000000014 /* DeliveryShareContent.swift in Sources */,
 				19ABC02426D5500000000016 /* ShareSheet.swift in Sources */,
 				19ABC02626D5500000000018 /* ConfettiView.swift in Sources */,
+				BCWATCH03599FA2E8BA070 /* SharedDeliveryItem.swift in Sources */,
+				BCWATCH0369939F397947D /* SharedDataManager.swift in Sources */,
+				WCMGR001A1B2C3D4E5F6 /* WatchConnectivityManager.swift in Sources */,
+				WDATA001A1B2C3D4E5F6 /* WatchDeliveryData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -801,7 +936,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BCWATCH043BEED89F960F1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BCWATCH011B442929E4593 /* BlackCatWatchApp.swift in Sources */,
+				BCWATCH01214E7882B14E5 /* ContentView.swift in Sources */,
+				BCWATCH0130478CB7770DC /* WatchDeliveryViewModel.swift in Sources */,
+				BCWATCH014A6F97A76425E /* WatchDeliveryItem.swift in Sources */,
+				BCWATCH0338061C1008830 /* SharedDeliveryItem.swift in Sources */,
+				BCWATCH034A66BD580E85F /* SharedDataManager.swift in Sources */,
+				WDATA003A1B2C3D4E5F6 /* WatchDeliveryData.swift in Sources */,
+				BCWATCH05A12345678901 /* WatchDeliveryListView.swift in Sources */,
+				BCWATCH05C12345678901 /* WatchDeliveryDetailView.swift in Sources */,
+				BCWATCH05E12345678901 /* ComplicationController.swift in Sources */,
+				BCWATCH06012345678901 /* WatchConnectivityManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
 
 /* Begin PBXTargetDependency section */
 		197A43FA29E137F800D111B2 /* PBXTargetDependency */ = {
@@ -1179,7 +1333,58 @@
 			};
 			name = Release;
 		};
+		BCWATCH04797412A78246D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 56787CM63P;
+				INFOPLIST_FILE = BlackCatWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = tosh7.BlackCat.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		BCWATCH048EC73E8494380 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 56787CM63P;
+				INFOPLIST_FILE = BlackCatWatch/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = tosh7.BlackCat.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
+
 
 /* Begin XCConfigurationList section */
 		197A43FD29E137F800D111B2 /* Build configuration list for PBXNativeTarget "BlackCatTests" */ = {
@@ -1236,7 +1441,17 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		BCWATCH0460BC07372DDE1 /* Build configuration list for PBXNativeTarget "BlackCatWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCWATCH04797412A78246D /* Debug */,
+				BCWATCH048EC73E8494380 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
 	};
 	rootObject = 2B5AC1D12670EBAF00CB80F6 /* Project object */;
 }

--- a/BlackCat/BlackCatApp.swift
+++ b/BlackCat/BlackCatApp.swift
@@ -3,6 +3,7 @@ import Domain
 import WidgetKit
 import UserNotifications
 import BackgroundTasks
+import WatchConnectivity
 
 let apiClient = ApiClient.shared
 
@@ -17,12 +18,18 @@ struct BlackCatApp: App {
     /// バックグラウンド更新マネージャーの初期化
     private let backgroundRefreshManager = BackgroundRefreshManager.shared
 
+    /// Watch Connectivityマネージャーの初期化
+    private let watchConnectivityManager = WatchConnectivityManager.shared
+
     init() {
         // アプリ起動時に通知の許可をリクエスト
         setupNotifications()
 
         // バックグラウンドタスクを登録
         setupBackgroundTasks()
+
+        // Watch Connectivityセッションをアクティベート
+        setupWatchConnectivity()
     }
 
     var body: some Scene {
@@ -83,6 +90,15 @@ struct BlackCatApp: App {
         }
     }
 
+    // MARK: - Watch Connectivity Setup
+
+    /// Watch Connectivityのセットアップ
+    private func setupWatchConnectivity() {
+        // WatchConnectivityManagerはシングルトンで初期化時にセッションをアクティベート
+        // ここでは追加の初期化が必要な場合に備えて参照を保持
+        print("[BlackCatApp] Watch Connectivity initialized, connected: \(watchConnectivityManager.isWatchConnected)")
+    }
+
     /// 通知タップ時のハンドリング
     private func handleNotificationTap(_ notification: Foundation.Notification) {
         guard let userInfo = notification.userInfo,
@@ -130,6 +146,20 @@ extension BlackCatApp {
 
         WidgetDataManager.shared.saveDeliveryItems(widgetItems)
         WidgetCenter.shared.reloadTimelines(ofKind: "BlackCarWidget")
+    }
+}
+
+// MARK: - Watch Data Synchronization
+
+extension BlackCatApp {
+    /// アプリからApple Watchへデータを同期する
+    /// DeliveryListViewModelの更新時に呼び出す
+    static func syncWatchData(deliveryItems: [DeliveryItem]) {
+        let watchItems = deliveryItems.map { item in
+            WatchDeliveryData(from: item, carrier: item.carrier)
+        }
+
+        WatchConnectivityManager.shared.sendDeliveries(watchItems)
     }
 }
 

--- a/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
+++ b/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
@@ -3,6 +3,7 @@ import Domain
 import Combine
 import WidgetKit
 import UserNotifications
+import WatchConnectivity
 
 // MARK: - Filter & Sort Types
 
@@ -117,7 +118,12 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
     /// 通知マネージャー
     private let notificationManager = NotificationManager.shared
 
+    /// Watch Connectivityマネージャー
+    private let watchConnectivityManager = WatchConnectivityManager.shared
+
     init() {
+        // Watch Connectivityのデータプロバイダーを設定
+        setupWatchConnectivity()
         $onAppearPublisher.sink { [weak self] _ in
             guard let self,
                   self.shouldReload else { return }
@@ -290,6 +296,38 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
 
             // ウィジェットにデータを同期
             BlackCatApp.syncWidgetData(deliveryItems: tnekoClient.deliveryList)
+
+            // Apple Watchにデータを同期
+            BlackCatApp.syncWatchData(deliveryItems: tnekoClient.deliveryList)
+        }
+    }
+
+    // MARK: - Watch Connectivity Setup
+
+    /// Watch Connectivityのセットアップ
+    private func setupWatchConnectivity() {
+        // データプロバイダーを設定
+        watchConnectivityManager.setDeliveryDataProvider { [weak self] in
+            guard let self = self else { return [] }
+            return self.deliveryList.map { item in
+                WatchDeliveryData(from: item, carrier: item.carrier)
+            }
+        }
+
+        // ステータス更新ハンドラーを設定
+        watchConnectivityManager.setStatusRefreshHandler { [weak self] completion in
+            guard let self = self else {
+                completion(false)
+                return
+            }
+
+            // データを再読み込み
+            Task { @MainActor in
+                self.loadItem()
+                // 少し待機してからcompletionを呼び出す
+                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2秒待機
+                completion(true)
+            }
         }
     }
 

--- a/BlackCat/Utils/WatchConnectivityManager.swift
+++ b/BlackCat/Utils/WatchConnectivityManager.swift
@@ -1,0 +1,424 @@
+//
+//  WatchConnectivityManager.swift
+//  BlackCat
+//
+//  iOS側のWatch Connectivity管理クラス
+//  Apple Watchとの配達データ同期を担当
+//
+
+import Foundation
+import WatchConnectivity
+import Combine
+
+// MARK: - iOS側 WatchConnectivityManager
+
+/// iOSアプリ側のWatch Connectivity管理クラス
+/// シングルトンパターンで実装し、アプリ全体で共有
+final class WatchConnectivityManager: NSObject, ObservableObject {
+
+    // MARK: - Singleton
+
+    static let shared = WatchConnectivityManager()
+
+    // MARK: - Published Properties
+
+    /// 同期状態
+    @Published private(set) var syncState: WatchSyncState = .idle
+
+    /// Apple Watchが接続されているか
+    @Published private(set) var isWatchConnected: Bool = false
+
+    /// Apple Watchがリーチャブルか（即時通信可能か）
+    @Published private(set) var isWatchReachable: Bool = false
+
+    /// Apple Watchアプリがインストールされているか
+    @Published private(set) var isWatchAppInstalled: Bool = false
+
+    /// 最後の同期日時
+    @Published private(set) var lastSyncDate: Date?
+
+    // MARK: - Private Properties
+
+    private var session: WCSession?
+    private var cancellables = Set<AnyCancellable>()
+
+    /// データ取得用のコールバック
+    private var deliveryDataProvider: (() -> [WatchDeliveryData])?
+
+    /// ステータス更新リクエスト用のコールバック
+    private var statusRefreshHandler: ((@escaping (Bool) -> Void) -> Void)?
+
+    // MARK: - Initialization
+
+    private override init() {
+        super.init()
+        setupSession()
+    }
+
+    // MARK: - Setup
+
+    /// WCSessionのセットアップ
+    private func setupSession() {
+        guard WCSession.isSupported() else {
+            print("[WatchConnectivity] WCSession is not supported on this device")
+            return
+        }
+
+        session = WCSession.default
+        session?.delegate = self
+        session?.activate()
+
+        print("[WatchConnectivity] iOS session setup completed")
+    }
+
+    // MARK: - Public Methods
+
+    /// 配達データプロバイダーを設定
+    /// - Parameter provider: 配達データを返すクロージャ
+    func setDeliveryDataProvider(_ provider: @escaping () -> [WatchDeliveryData]) {
+        self.deliveryDataProvider = provider
+    }
+
+    /// ステータス更新ハンドラーを設定
+    /// - Parameter handler: 更新リクエストを処理するクロージャ
+    func setStatusRefreshHandler(_ handler: @escaping (@escaping (Bool) -> Void) -> Void) {
+        self.statusRefreshHandler = handler
+    }
+
+    /// Apple Watchに配達データを送信
+    /// - Parameter deliveries: 送信する配達データ
+    func sendDeliveries(_ deliveries: [WatchDeliveryData]) {
+        guard let session = session, session.activationState == .activated else {
+            print("[WatchConnectivity] Session not activated")
+            syncState = .error(WatchSyncError.sessionNotActivated.localizedDescription)
+            return
+        }
+
+        syncState = .syncing
+
+        // Application Contextを使用してバックグラウンドでも同期
+        let activeCount = deliveries.filter { !$0.isDelivered }.count
+        let deliveredCount = deliveries.filter { $0.isDelivered }.count
+
+        let context = WatchApplicationContext(
+            lastSyncDate: Date(),
+            activeDeliveryCount: activeCount,
+            deliveredCount: deliveredCount,
+            deliveries: deliveries
+        )
+
+        do {
+            try session.updateApplicationContext(context.toDictionary())
+            lastSyncDate = Date()
+            syncState = .success
+
+            print("[WatchConnectivity] Application context updated with \(deliveries.count) deliveries")
+        } catch {
+            print("[WatchConnectivity] Failed to update application context: \(error)")
+            syncState = .error(error.localizedDescription)
+        }
+
+        // Watchがリーチャブルならメッセージも送信（即時反映のため）
+        if session.isReachable {
+            sendMessageToWatch(deliveries: deliveries)
+        }
+    }
+
+    /// 単一の配達データ更新を送信
+    /// - Parameter delivery: 更新する配達データ
+    func sendDeliveryUpdate(_ delivery: WatchDeliveryData) {
+        guard let session = session,
+              session.activationState == .activated,
+              session.isReachable else {
+            // リーチャブルでない場合はApplication Contextで同期
+            if let deliveries = deliveryDataProvider?() {
+                sendDeliveries(deliveries)
+            }
+            return
+        }
+
+        do {
+            let data = try JSONEncoder().encode(delivery)
+            let message: [String: Any] = [
+                "type": WatchMessageType.deliveryUpdate.rawValue,
+                "timestamp": Date().timeIntervalSince1970,
+                "payload": data
+            ]
+
+            session.sendMessage(message, replyHandler: nil) { error in
+                print("[WatchConnectivity] Failed to send delivery update: \(error)")
+            }
+
+            print("[WatchConnectivity] Delivery update sent for ID: \(delivery.deliveryID)")
+        } catch {
+            print("[WatchConnectivity] Failed to encode delivery data: \(error)")
+        }
+    }
+
+    /// 配達削除通知を送信
+    /// - Parameter deliveryID: 削除された配達ID
+    func sendDeliveryDeleted(deliveryID: Int) {
+        guard let session = session,
+              session.activationState == .activated else {
+            return
+        }
+
+        let message: [String: Any] = [
+            "type": WatchMessageType.deliveryDeleted.rawValue,
+            "timestamp": Date().timeIntervalSince1970,
+            "deliveryID": deliveryID
+        ]
+
+        if session.isReachable {
+            session.sendMessage(message, replyHandler: nil) { error in
+                print("[WatchConnectivity] Failed to send deletion notification: \(error)")
+            }
+        }
+
+        // Application Contextも更新
+        if let deliveries = deliveryDataProvider?() {
+            sendDeliveries(deliveries)
+        }
+
+        print("[WatchConnectivity] Delivery deletion notification sent for ID: \(deliveryID)")
+    }
+
+    /// 手動で同期を実行
+    func syncNow() {
+        guard let deliveries = deliveryDataProvider?() else {
+            print("[WatchConnectivity] No delivery data provider set")
+            return
+        }
+
+        sendDeliveries(deliveries)
+    }
+
+    // MARK: - Private Methods
+
+    /// メッセージでWatchに配達データを送信
+    private func sendMessageToWatch(deliveries: [WatchDeliveryData]) {
+        guard let session = session, session.isReachable else {
+            return
+        }
+
+        do {
+            let data = try JSONEncoder().encode(deliveries)
+            let message: [String: Any] = [
+                "type": WatchMessageType.allDeliveriesResponse.rawValue,
+                "timestamp": Date().timeIntervalSince1970,
+                "payload": data
+            ]
+
+            session.sendMessage(message, replyHandler: { reply in
+                print("[WatchConnectivity] Watch acknowledged receipt")
+            }) { error in
+                print("[WatchConnectivity] Failed to send message: \(error)")
+            }
+        } catch {
+            print("[WatchConnectivity] Failed to encode deliveries: \(error)")
+        }
+    }
+
+    /// Watchからのリクエストを処理
+    private func handleWatchRequest(message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+        guard let typeString = message["type"] as? String,
+              let messageType = WatchMessageType(rawValue: typeString) else {
+            replyHandler(["error": "Invalid message type"])
+            return
+        }
+
+        switch messageType {
+        case .requestAllDeliveries:
+            handleAllDeliveriesRequest(replyHandler: replyHandler)
+
+        case .requestStatusRefresh:
+            handleStatusRefreshRequest(replyHandler: replyHandler)
+
+        case .heartbeat:
+            replyHandler([
+                "type": WatchMessageType.heartbeat.rawValue,
+                "timestamp": Date().timeIntervalSince1970
+            ])
+
+        default:
+            replyHandler(["error": "Unsupported message type"])
+        }
+    }
+
+    /// 全配達データリクエストの処理
+    private func handleAllDeliveriesRequest(replyHandler: @escaping ([String: Any]) -> Void) {
+        guard let deliveries = deliveryDataProvider?() else {
+            replyHandler([
+                "type": WatchMessageType.error.rawValue,
+                "error": "No delivery data available"
+            ])
+            return
+        }
+
+        do {
+            let data = try JSONEncoder().encode(deliveries)
+            replyHandler([
+                "type": WatchMessageType.allDeliveriesResponse.rawValue,
+                "timestamp": Date().timeIntervalSince1970,
+                "payload": data
+            ])
+
+            print("[WatchConnectivity] Sent \(deliveries.count) deliveries to Watch")
+        } catch {
+            replyHandler([
+                "type": WatchMessageType.error.rawValue,
+                "error": error.localizedDescription
+            ])
+        }
+    }
+
+    /// ステータス更新リクエストの処理
+    private func handleStatusRefreshRequest(replyHandler: @escaping ([String: Any]) -> Void) {
+        guard let refreshHandler = statusRefreshHandler else {
+            replyHandler([
+                "type": WatchMessageType.error.rawValue,
+                "error": "Refresh handler not configured"
+            ])
+            return
+        }
+
+        refreshHandler { [weak self] success in
+            if success {
+                // 更新成功、最新データを返す
+                if let deliveries = self?.deliveryDataProvider?() {
+                    do {
+                        let data = try JSONEncoder().encode(deliveries)
+                        replyHandler([
+                            "type": WatchMessageType.statusRefreshComplete.rawValue,
+                            "timestamp": Date().timeIntervalSince1970,
+                            "payload": data
+                        ])
+                    } catch {
+                        replyHandler([
+                            "type": WatchMessageType.error.rawValue,
+                            "error": error.localizedDescription
+                        ])
+                    }
+                }
+            } else {
+                replyHandler([
+                    "type": WatchMessageType.error.rawValue,
+                    "error": "Refresh failed"
+                ])
+            }
+        }
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchConnectivityManager: WCSessionDelegate {
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async { [weak self] in
+            if let error = error {
+                print("[WatchConnectivity] Activation failed: \(error)")
+                self?.syncState = .error(error.localizedDescription)
+                return
+            }
+
+            print("[WatchConnectivity] Session activated with state: \(activationState.rawValue)")
+
+            self?.isWatchConnected = session.isPaired
+            self?.isWatchAppInstalled = session.isWatchAppInstalled
+            self?.isWatchReachable = session.isReachable
+        }
+    }
+
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        print("[WatchConnectivity] Session became inactive")
+    }
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        print("[WatchConnectivity] Session deactivated")
+        // 再アクティベート
+        session.activate()
+    }
+
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        DispatchQueue.main.async { [weak self] in
+            self?.isWatchConnected = session.isPaired
+            self?.isWatchAppInstalled = session.isWatchAppInstalled
+            self?.isWatchReachable = session.isReachable
+
+            print("[WatchConnectivity] Watch state changed - Paired: \(session.isPaired), Installed: \(session.isWatchAppInstalled), Reachable: \(session.isReachable)")
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async { [weak self] in
+            self?.isWatchReachable = session.isReachable
+
+            print("[WatchConnectivity] Reachability changed: \(session.isReachable)")
+
+            // リーチャブルになったら自動同期
+            if session.isReachable {
+                self?.syncNow()
+            }
+        }
+    }
+
+    // メッセージ受信（リプライハンドラーあり）
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+        print("[WatchConnectivity] Received message with reply handler")
+        handleWatchRequest(message: message, replyHandler: replyHandler)
+    }
+
+    // メッセージ受信（リプライハンドラーなし）
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        print("[WatchConnectivity] Received message without reply handler")
+
+        guard let typeString = message["type"] as? String,
+              let messageType = WatchMessageType(rawValue: typeString) else {
+            return
+        }
+
+        switch messageType {
+        case .heartbeat:
+            print("[WatchConnectivity] Heartbeat received from Watch")
+        default:
+            break
+        }
+    }
+
+    // Application Context受信
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        print("[WatchConnectivity] Received application context from Watch")
+        // Watchからのコンテキスト更新があれば処理（通常はWatchへの送信のみ）
+    }
+
+    // ユーザー情報転送完了
+    func session(_ session: WCSession, didFinish userInfoTransfer: WCSessionUserInfoTransfer, error: Error?) {
+        if let error = error {
+            print("[WatchConnectivity] User info transfer failed: \(error)")
+        } else {
+            print("[WatchConnectivity] User info transfer completed")
+        }
+    }
+}
+
+// MARK: - DeliveryItem Extension
+
+/// DeliveryItemからWatchDeliveryDataへの変換
+extension WatchDeliveryData {
+    /// DeliveryItemから初期化（iOS側で使用）
+    /// 注: この初期化子はiOSアプリ側でのみ使用
+    init(from item: DeliveryItem, carrier: DeliveryCarrier) {
+        self.id = item.id.uuidString
+        self.deliveryID = item.deliveryID
+        self.carrierName = carrier.displayName
+        self.carrierIcon = carrier.iconName
+        self.latestStatus = item.latestStatus?.status ?? "不明"
+        self.latestStatusType = item.latestStatusType.map { String(describing: $0) } ?? "unknown"
+        self.latestDate = item.latestStatus?.date ?? ""
+        self.latestTime = item.latestStatus?.time
+        self.latestLocation = item.latestStatus?.shopName ?? ""
+        self.registeredDate = item.registeredDate
+        self.isDelivered = item.latestStatusType == .delivered
+    }
+}

--- a/BlackCatWatch/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0xCB",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0xCB",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,123 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "24x24",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "29x29",
+      "role" : "companionSettings"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "3x",
+      "size" : "29x29",
+      "role" : "companionSettings"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "33x33",
+      "role" : "notificationCenter",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "40x40",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "44x44",
+      "role" : "appLauncher",
+      "subtype" : "40mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "46x46",
+      "role" : "appLauncher",
+      "subtype" : "41mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "50x50",
+      "role" : "appLauncher",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "51x51",
+      "role" : "appLauncher",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "54x54",
+      "role" : "appLauncher",
+      "subtype" : "49mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "86x86",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "98x98",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "108x108",
+      "role" : "quickLook",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "117x117",
+      "role" : "quickLook",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "129x129",
+      "role" : "quickLook",
+      "subtype" : "49mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/StatusDelivered.colorset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/StatusDelivered.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.800",
+          "red" : "0.298"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.400",
+          "green" : "0.800",
+          "red" : "0.298"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/StatusInTransit.colorset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/StatusInTransit.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.271",
+          "green" : "0.796",
+          "red" : "0.929"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.271",
+          "green" : "0.796",
+          "red" : "0.929"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/StatusPending.colorset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/StatusPending.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.600",
+          "green" : "0.600",
+          "red" : "0.600"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.700",
+          "green" : "0.700",
+          "red" : "0.700"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/WatchAccent.colorset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/WatchAccent.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0xCB",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0xCB",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Assets.xcassets/WatchBackground.colorset/Contents.json
+++ b/BlackCatWatch/Assets.xcassets/WatchBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2E",
+          "green" : "0x1A",
+          "red" : "0x1A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/BlackCatWatchApp.swift
+++ b/BlackCatWatch/BlackCatWatchApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct BlackCatWatchApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/BlackCatWatch/Complications/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/BlackCatWatch/Complications/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0xCB",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x45",
+          "green" : "0xCB",
+          "red" : "0xED"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Complications/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/BlackCatWatch/Complications/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,123 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "24x24",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "29x29",
+      "role" : "companionSettings"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "3x",
+      "size" : "29x29",
+      "role" : "companionSettings"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "33x33",
+      "role" : "notificationCenter",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "40x40",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "44x44",
+      "role" : "appLauncher",
+      "subtype" : "40mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "46x46",
+      "role" : "appLauncher",
+      "subtype" : "41mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "50x50",
+      "role" : "appLauncher",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "51x51",
+      "role" : "appLauncher",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "54x54",
+      "role" : "appLauncher",
+      "subtype" : "49mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "86x86",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "98x98",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "108x108",
+      "role" : "quickLook",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "117x117",
+      "role" : "quickLook",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "size" : "129x129",
+      "role" : "quickLook",
+      "subtype" : "49mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Complications/Assets.xcassets/Contents.json
+++ b/BlackCatWatch/Complications/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Complications/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/BlackCatWatch/Complications/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.180",
+          "green" : "0.102",
+          "red" : "0.102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BlackCatWatch/Complications/ComplicationController.swift
+++ b/BlackCatWatch/Complications/ComplicationController.swift
@@ -1,0 +1,487 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Watch Complication Entry
+
+/// Complication用のTimelineEntry
+struct WatchComplicationEntry: TimelineEntry {
+    let date: Date
+    let deliveries: [WatchDeliveryData]
+    let lastUpdate: Date?
+
+    /// アクティブな配達（配達完了以外）の数
+    var activeDeliveryCount: Int {
+        deliveries.filter { !$0.isDelivered }.count
+    }
+
+    /// 最新のアクティブな配達
+    var latestActiveDelivery: WatchDeliveryData? {
+        deliveries.first { !$0.isDelivered } ?? deliveries.first
+    }
+
+    // MARK: - Static Entries
+
+    static var placeholder: WatchComplicationEntry {
+        WatchComplicationEntry(
+            date: Date(),
+            deliveries: [
+                WatchDeliveryData(
+                    id: UUID().uuidString,
+                    deliveryID: 123456789012,
+                    carrierName: "ヤマト運輸",
+                    carrierIcon: "shippingbox.fill",
+                    latestStatus: "配達中",
+                    latestStatusType: "delivering",
+                    latestDate: "01/29",
+                    latestTime: "14:30",
+                    latestLocation: "配送センター",
+                    registeredDate: Date(),
+                    isDelivered: false
+                )
+            ],
+            lastUpdate: Date()
+        )
+    }
+
+    static var empty: WatchComplicationEntry {
+        WatchComplicationEntry(
+            date: Date(),
+            deliveries: [],
+            lastUpdate: nil
+        )
+    }
+
+    static var preview: WatchComplicationEntry {
+        WatchComplicationEntry(
+            date: Date(),
+            deliveries: [
+                WatchDeliveryData(
+                    id: UUID().uuidString,
+                    deliveryID: 123456789012,
+                    carrierName: "ヤマト運輸",
+                    carrierIcon: "shippingbox.fill",
+                    latestStatus: "配達中",
+                    latestStatusType: "delivering",
+                    latestDate: "01/29",
+                    latestTime: "14:30",
+                    latestLocation: "ヤマト運輸",
+                    registeredDate: Date(),
+                    isDelivered: false
+                ),
+                WatchDeliveryData(
+                    id: UUID().uuidString,
+                    deliveryID: 987654321098,
+                    carrierName: "佐川急便",
+                    carrierIcon: "truck.box.fill",
+                    latestStatus: "輸送中",
+                    latestStatusType: "shipping",
+                    latestDate: "01/28",
+                    latestTime: "10:15",
+                    latestLocation: "佐川急便",
+                    registeredDate: Date(),
+                    isDelivered: false
+                )
+            ],
+            lastUpdate: Date()
+        )
+    }
+}
+
+// MARK: - WatchDeliveryData Extension for Complication
+
+extension WatchDeliveryData {
+    /// ステータスに対応するSF Symbolアイコン（Complication用）
+    var complicationIcon: String {
+        switch latestStatusType {
+        case "received":
+            return "shippingbox"
+        case "sended":
+            return "paperplane.fill"
+        case "shipping":
+            return "truck.box.fill"
+        case "delivering":
+            return "figure.walk"
+        case "delivered":
+            return "checkmark.circle.fill"
+        default:
+            return "questionmark.circle"
+        }
+    }
+
+    /// 短縮ステータス名（Complication用）
+    var shortStatusName: String {
+        switch latestStatusType {
+        case "received":
+            return "受付"
+        case "sended":
+            return "発送"
+        case "shipping":
+            return "輸送"
+        case "delivering":
+            return "配達"
+        case "delivered":
+            return "完了"
+        default:
+            return "不明"
+        }
+    }
+
+    /// ステータスの日本語表示名（Complication用）
+    var displayStatusName: String {
+        switch latestStatusType {
+        case "received":
+            return "荷物受付"
+        case "sended":
+            return "発送済み"
+        case "shipping":
+            return "輸送中"
+        case "delivering":
+            return "配達中"
+        case "delivered":
+            return "配達完了"
+        default:
+            return "不明"
+        }
+    }
+
+    /// 伝票番号（文字列形式）
+    var trackingNumberString: String {
+        String(deliveryID)
+    }
+}
+
+// MARK: - Complication Data Manager
+
+/// Complication用のデータ管理クラス
+/// WatchConnectivityManagerと連携してデータを取得
+final class ComplicationDataManager {
+    static let shared = ComplicationDataManager()
+
+    /// App Group identifier
+    private let appGroupIdentifier = "group.com.blackcat.delivery"
+    private let deliveryDataKey = "WatchDeliveryDataForComplication"
+    private let lastUpdateKey = "ComplicationLastUpdate"
+
+    private var sharedDefaults: UserDefaults? {
+        return UserDefaults(suiteName: appGroupIdentifier)
+    }
+
+    private init() {}
+
+    /// 配達データを保存（WatchConnectivityManagerから呼び出し）
+    func saveDeliveries(_ deliveries: [WatchDeliveryData]) {
+        let encoder = JSONEncoder()
+        if let encoded = try? encoder.encode(deliveries) {
+            sharedDefaults?.set(encoded, forKey: deliveryDataKey)
+            sharedDefaults?.set(Date(), forKey: lastUpdateKey)
+        }
+    }
+
+    /// 配達データを取得
+    func loadDeliveries() -> [WatchDeliveryData] {
+        guard let data = sharedDefaults?.data(forKey: deliveryDataKey) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        if let deliveries = try? decoder.decode([WatchDeliveryData].self, from: data) {
+            return deliveries
+        }
+        return []
+    }
+
+    /// 最後の更新日時を取得
+    func lastUpdateDate() -> Date? {
+        return sharedDefaults?.object(forKey: lastUpdateKey) as? Date
+    }
+
+    /// Complicationをリロード
+    func reloadComplications() {
+        WidgetCenter.shared.reloadTimelines(ofKind: "BlackCatWatchComplication")
+    }
+}
+
+// MARK: - Timeline Provider
+
+/// Complication用のTimelineProvider
+struct ComplicationTimelineProvider: TimelineProvider {
+    typealias Entry = WatchComplicationEntry
+
+    func placeholder(in context: Context) -> WatchComplicationEntry {
+        return .placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (WatchComplicationEntry) -> Void) {
+        if context.isPreview {
+            completion(.preview)
+        } else {
+            let deliveries = ComplicationDataManager.shared.loadDeliveries()
+            let entry = WatchComplicationEntry(
+                date: Date(),
+                deliveries: deliveries,
+                lastUpdate: ComplicationDataManager.shared.lastUpdateDate()
+            )
+            completion(entry)
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WatchComplicationEntry>) -> Void) {
+        let deliveries = ComplicationDataManager.shared.loadDeliveries()
+        let currentDate = Date()
+
+        // 現在のエントリを作成
+        let entry = WatchComplicationEntry(
+            date: currentDate,
+            deliveries: deliveries,
+            lastUpdate: ComplicationDataManager.shared.lastUpdateDate()
+        )
+
+        // 15分後に次の更新をスケジュール
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: currentDate) ?? currentDate.addingTimeInterval(900)
+
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+// MARK: - Complication Views
+
+/// accessoryCircular用ビュー - 小さな円形（ステータスアイコン）
+struct AccessoryCircularView: View {
+    let entry: WatchComplicationEntry
+
+    var body: some View {
+        if let delivery = entry.latestActiveDelivery {
+            ZStack {
+                AccessoryWidgetBackground()
+                VStack(spacing: 2) {
+                    Image(systemName: delivery.complicationIcon)
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(delivery.statusColor)
+
+                    if entry.activeDeliveryCount > 1 {
+                        Text("\(entry.activeDeliveryCount)")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        } else {
+            ZStack {
+                AccessoryWidgetBackground()
+                Image(systemName: "shippingbox")
+                    .font(.system(size: 18))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+}
+
+/// accessoryRectangular用ビュー - 長方形（伝票番号+ステータス）
+struct AccessoryRectangularView: View {
+    let entry: WatchComplicationEntry
+
+    var body: some View {
+        if let delivery = entry.latestActiveDelivery {
+            VStack(alignment: .leading, spacing: 2) {
+                // ステータス行
+                HStack(spacing: 4) {
+                    Image(systemName: delivery.complicationIcon)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(delivery.statusColor)
+
+                    Text(delivery.displayStatusName)
+                        .font(.system(size: 13, weight: .semibold))
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    if entry.activeDeliveryCount > 1 {
+                        Text("+\(entry.activeDeliveryCount - 1)")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                // 伝票番号
+                Text(delivery.trackingNumberString)
+                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+
+                // 日時
+                HStack(spacing: 4) {
+                    if !delivery.latestDate.isEmpty {
+                        Text(delivery.latestDate)
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                    }
+
+                    if let time = delivery.latestTime {
+                        Text(time)
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 4) {
+                    Image(systemName: "shippingbox")
+                        .font(.system(size: 12))
+                    Text("配達状況")
+                        .font(.system(size: 13, weight: .semibold))
+                }
+
+                Text("追跡中の荷物はありません")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+/// accessoryInline用ビュー - インライン（ステータステキスト）
+struct AccessoryInlineView: View {
+    let entry: WatchComplicationEntry
+
+    var body: some View {
+        if let delivery = entry.latestActiveDelivery {
+            Label {
+                if entry.activeDeliveryCount > 1 {
+                    Text("\(delivery.shortStatusName) (\(entry.activeDeliveryCount)件)")
+                } else {
+                    Text(delivery.displayStatusName)
+                }
+            } icon: {
+                Image(systemName: delivery.complicationIcon)
+            }
+        } else {
+            Label("配達なし", systemImage: "shippingbox")
+        }
+    }
+}
+
+/// accessoryCorner用ビュー - コーナー（アイコン）
+struct AccessoryCornerView: View {
+    let entry: WatchComplicationEntry
+
+    var body: some View {
+        if let delivery = entry.latestActiveDelivery {
+            ZStack {
+                Image(systemName: delivery.complicationIcon)
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(delivery.statusColor)
+            }
+            .widgetLabel {
+                Text(delivery.shortStatusName)
+            }
+        } else {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 20))
+                .foregroundColor(.secondary)
+                .widgetLabel {
+                    Text("配達")
+                }
+        }
+    }
+}
+
+// MARK: - Main Complication Widget
+
+/// BlackCat Watch Complication Widget
+struct BlackCatWatchComplication: Widget {
+    let kind: String = "BlackCatWatchComplication"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: ComplicationTimelineProvider()) { entry in
+            ComplicationEntryView(entry: entry)
+                .widgetURL(URL(string: "blackcat://watch/delivery"))
+        }
+        .configurationDisplayName("配達状況")
+        .description("配達中の荷物の最新状況を文字盤に表示します")
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline,
+            .accessoryCorner
+        ])
+    }
+}
+
+// MARK: - Complication Entry View
+
+/// Complicationファミリーに応じたビューを表示
+struct ComplicationEntryView: View {
+    @Environment(\.widgetFamily) var family
+    let entry: WatchComplicationEntry
+
+    var body: some View {
+        switch family {
+        case .accessoryCircular:
+            AccessoryCircularView(entry: entry)
+        case .accessoryRectangular:
+            AccessoryRectangularView(entry: entry)
+        case .accessoryInline:
+            AccessoryInlineView(entry: entry)
+        case .accessoryCorner:
+            AccessoryCornerView(entry: entry)
+        default:
+            // フォールバック: Circularビューを使用
+            AccessoryCircularView(entry: entry)
+        }
+    }
+}
+
+// MARK: - Widget Bundle
+
+/// Complication Widget Bundle
+@main
+struct BlackCatWatchWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        BlackCatWatchComplication()
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+struct BlackCatWatchComplication_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            // Circular - アクティブな配達あり
+            ComplicationEntryView(entry: .preview)
+                .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+                .previewDisplayName("Circular - Active")
+
+            // Circular - 配達なし
+            ComplicationEntryView(entry: .empty)
+                .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+                .previewDisplayName("Circular - Empty")
+
+            // Rectangular - アクティブな配達あり
+            ComplicationEntryView(entry: .preview)
+                .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+                .previewDisplayName("Rectangular - Active")
+
+            // Rectangular - 配達なし
+            ComplicationEntryView(entry: .empty)
+                .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+                .previewDisplayName("Rectangular - Empty")
+
+            // Inline
+            ComplicationEntryView(entry: .preview)
+                .previewContext(WidgetPreviewContext(family: .accessoryInline))
+                .previewDisplayName("Inline")
+
+            // Corner
+            ComplicationEntryView(entry: .preview)
+                .previewContext(WidgetPreviewContext(family: .accessoryCorner))
+                .previewDisplayName("Corner")
+        }
+    }
+}
+#endif

--- a/BlackCatWatch/Complications/Info.plist
+++ b/BlackCatWatch/Complications/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>BlackCat</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.2.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/BlackCatWatch/ContentView.swift
+++ b/BlackCatWatch/ContentView.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var viewModel = WatchDeliveryViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading {
+                    LoadingView()
+                } else if viewModel.deliveries.isEmpty {
+                    EmptyStateView(isPhoneReachable: viewModel.isPhoneReachable)
+                } else {
+                    DeliveryListView(
+                        deliveries: viewModel.deliveries,
+                        lastSyncDate: viewModel.formattedLastSyncDate
+                    )
+                }
+            }
+            .navigationTitle("配達状況")
+        }
+        .onAppear {
+            viewModel.loadDeliveries()
+        }
+        .refreshable {
+            viewModel.refreshStatus()
+        }
+    }
+}
+
+// MARK: - Loading View
+
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle())
+                .scaleEffect(1.2)
+
+            Text("読み込み中...")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+// MARK: - Empty State View
+
+struct EmptyStateView: View {
+    let isPhoneReachable: Bool
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 40))
+                .foregroundColor(.gray)
+
+            Text("追跡中の荷物がありません")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Text("iPhoneアプリで\n荷物を追加してください")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            if !isPhoneReachable {
+                HStack(spacing: 4) {
+                    Image(systemName: "iphone.slash")
+                        .font(.caption2)
+                    Text("iPhoneに接続できません")
+                        .font(.caption2)
+                }
+                .foregroundColor(.orange)
+                .padding(.top, 8)
+            }
+        }
+        .padding()
+    }
+}
+
+// MARK: - Delivery List View
+
+struct DeliveryListView: View {
+    let deliveries: [WatchDeliveryData]
+    let lastSyncDate: String
+
+    var body: some View {
+        List {
+            // 同期情報
+            Section {
+                HStack {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text("最終同期: \(lastSyncDate)")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            // 配達リスト
+            ForEach(deliveries) { item in
+                NavigationLink(destination: DeliveryDetailView(delivery: item)) {
+                    DeliveryRowView(delivery: item)
+                }
+            }
+        }
+        .listStyle(.carousel)
+    }
+}
+
+// MARK: - Delivery Row View
+
+struct DeliveryRowView: View {
+    let delivery: WatchDeliveryData
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Circle()
+                    .fill(delivery.statusColor)
+                    .frame(width: 8, height: 8)
+
+                Text(delivery.latestStatus)
+                    .font(.headline)
+                    .lineLimit(1)
+            }
+
+            Text(delivery.carrierName)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+
+            if !delivery.latestDate.isEmpty {
+                HStack(spacing: 4) {
+                    Text(delivery.latestDate)
+                    if let time = delivery.latestTime {
+                        Text(time)
+                    }
+                }
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Delivery Detail View
+
+struct DeliveryDetailView: View {
+    let delivery: WatchDeliveryData
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                // Status Header
+                HStack {
+                    ZStack {
+                        Circle()
+                            .fill(delivery.statusColor.opacity(0.2))
+                            .frame(width: 36, height: 36)
+
+                        Circle()
+                            .fill(delivery.statusColor)
+                            .frame(width: 28, height: 28)
+
+                        Image(systemName: delivery.statusIcon)
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+
+                    Text(delivery.latestStatus)
+                        .font(.headline)
+                }
+
+                Divider()
+
+                // Carrier Info
+                Label(delivery.carrierName, systemImage: delivery.carrierIcon)
+                    .font(.caption)
+
+                // Tracking Number
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("伝票番号")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+
+                    Text(String(delivery.deliveryID))
+                        .font(.caption)
+                        .fontDesign(.monospaced)
+                }
+
+                // Date Info
+                if !delivery.latestDate.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("最終更新")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+
+                        HStack {
+                            Text(delivery.latestDate)
+                            if let time = delivery.latestTime {
+                                Text(time)
+                            }
+                        }
+                        .font(.caption)
+                    }
+                }
+
+                // Location
+                if !delivery.latestLocation.isEmpty {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("場所")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+
+                        Text(delivery.latestLocation)
+                            .font(.caption)
+                    }
+                }
+
+                // Progress Bar
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("進捗")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+
+                        Spacer()
+
+                        Text("\(delivery.progressPercentage)%")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundColor(delivery.statusColor)
+                    }
+
+                    GeometryReader { geometry in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(Color.gray.opacity(0.3))
+                                .frame(height: 4)
+
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(delivery.statusColor)
+                                .frame(width: geometry.size.width * CGFloat(delivery.progressPercentage) / 100, height: 4)
+                        }
+                    }
+                    .frame(height: 4)
+                }
+                .padding(.top, 8)
+            }
+            .padding()
+        }
+        .navigationTitle("詳細")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ContentView()
+}

--- a/BlackCatWatch/Info.plist
+++ b/BlackCatWatch/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>BlackCat</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKApplication</key>
+	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>tosh7.BlackCat</string>
+	<key>WKRunsIndependentlyOfCompanionApp</key>
+	<false/>
+	<key>WKWatchOnly</key>
+	<false/>
+	<key>CLKComplicationPrincipalClass</key>
+	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
+</dict>
+</plist>

--- a/BlackCatWatch/Utils/WatchConnectivityManager.swift
+++ b/BlackCatWatch/Utils/WatchConnectivityManager.swift
@@ -1,0 +1,459 @@
+//
+//  WatchConnectivityManager.swift
+//  BlackCatWatch
+//
+//  watchOS側のWatch Connectivity管理クラス
+//  iOSアプリとの配達データ同期を担当
+//
+
+import Foundation
+import WatchConnectivity
+import Combine
+
+// MARK: - watchOS側 WatchConnectivityManager
+
+/// watchOSアプリ側のWatch Connectivity管理クラス
+/// シングルトンパターンで実装し、アプリ全体で共有
+final class WatchConnectivityManager: NSObject, ObservableObject {
+
+    // MARK: - Singleton
+
+    static let shared = WatchConnectivityManager()
+
+    // MARK: - Published Properties
+
+    /// 同期状態
+    @Published private(set) var syncState: WatchSyncState = .idle
+
+    /// iOSアプリがリーチャブルか（即時通信可能か）
+    @Published private(set) var isPhoneReachable: Bool = false
+
+    /// 配達データ
+    @Published private(set) var deliveries: [WatchDeliveryData] = []
+
+    /// アクティブな配達数
+    @Published private(set) var activeDeliveryCount: Int = 0
+
+    /// 配達完了数
+    @Published private(set) var deliveredCount: Int = 0
+
+    /// 最後の同期日時
+    @Published private(set) var lastSyncDate: Date?
+
+    /// エラーメッセージ
+    @Published var errorMessage: String?
+
+    // MARK: - Private Properties
+
+    private var session: WCSession?
+    private var cancellables = Set<AnyCancellable>()
+
+    /// リクエストタイムアウト（秒）
+    private let requestTimeout: TimeInterval = 30
+
+    // MARK: - Initialization
+
+    private override init() {
+        super.init()
+        setupSession()
+    }
+
+    // MARK: - Setup
+
+    /// WCSessionのセットアップ
+    private func setupSession() {
+        guard WCSession.isSupported() else {
+            print("[WatchConnectivity] WCSession is not supported on this device")
+            return
+        }
+
+        session = WCSession.default
+        session?.delegate = self
+        session?.activate()
+
+        print("[WatchConnectivity] Watch session setup completed")
+    }
+
+    // MARK: - Public Methods
+
+    /// iOSアプリから全配達データをリクエスト
+    func requestAllDeliveries() {
+        guard let session = session, session.activationState == .activated else {
+            print("[WatchConnectivity] Session not activated")
+            errorMessage = WatchSyncError.sessionNotActivated.localizedDescription
+            syncState = .error(WatchSyncError.sessionNotActivated.localizedDescription)
+            return
+        }
+
+        guard session.isReachable else {
+            print("[WatchConnectivity] iPhone is not reachable, using cached data")
+            // リーチャブルでない場合はApplication Contextから読み込み
+            loadFromApplicationContext()
+            return
+        }
+
+        syncState = .syncing
+        errorMessage = nil
+
+        let message: [String: Any] = [
+            "type": WatchMessageType.requestAllDeliveries.rawValue,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+
+        session.sendMessage(message, replyHandler: { [weak self] reply in
+            self?.handleDeliveriesResponse(reply)
+        }) { [weak self] error in
+            DispatchQueue.main.async {
+                print("[WatchConnectivity] Failed to request deliveries: \(error)")
+                self?.errorMessage = error.localizedDescription
+                self?.syncState = .error(error.localizedDescription)
+
+                // フォールバック: Application Contextから読み込み
+                self?.loadFromApplicationContext()
+            }
+        }
+    }
+
+    /// iOSアプリにステータス更新をリクエスト
+    func requestStatusRefresh() {
+        guard let session = session,
+              session.activationState == .activated,
+              session.isReachable else {
+            errorMessage = WatchSyncError.watchNotReachable.localizedDescription
+            syncState = .error(WatchSyncError.watchNotReachable.localizedDescription)
+            return
+        }
+
+        syncState = .syncing
+        errorMessage = nil
+
+        let message: [String: Any] = [
+            "type": WatchMessageType.requestStatusRefresh.rawValue,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+
+        session.sendMessage(message, replyHandler: { [weak self] reply in
+            self?.handleRefreshResponse(reply)
+        }) { [weak self] error in
+            DispatchQueue.main.async {
+                print("[WatchConnectivity] Failed to request refresh: \(error)")
+                self?.errorMessage = error.localizedDescription
+                self?.syncState = .error(error.localizedDescription)
+            }
+        }
+    }
+
+    /// ハートビートを送信（接続確認）
+    func sendHeartbeat() {
+        guard let session = session,
+              session.activationState == .activated,
+              session.isReachable else {
+            return
+        }
+
+        let message: [String: Any] = [
+            "type": WatchMessageType.heartbeat.rawValue,
+            "timestamp": Date().timeIntervalSince1970
+        ]
+
+        session.sendMessage(message, replyHandler: { reply in
+            print("[WatchConnectivity] Heartbeat acknowledged")
+        }) { error in
+            print("[WatchConnectivity] Heartbeat failed: \(error)")
+        }
+    }
+
+    /// キャッシュされたデータをクリア
+    func clearCache() {
+        DispatchQueue.main.async { [weak self] in
+            self?.deliveries = []
+            self?.activeDeliveryCount = 0
+            self?.deliveredCount = 0
+            self?.lastSyncDate = nil
+        }
+    }
+
+    // MARK: - Private Methods
+
+    /// Application Contextからデータを読み込み
+    private func loadFromApplicationContext() {
+        guard let session = session else { return }
+
+        let context = session.receivedApplicationContext
+
+        guard !context.isEmpty,
+              let appContext = WatchApplicationContext(dictionary: context) else {
+            print("[WatchConnectivity] No valid application context available")
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.deliveries = appContext.deliveries
+            self?.activeDeliveryCount = appContext.activeDeliveryCount
+            self?.deliveredCount = appContext.deliveredCount
+            self?.lastSyncDate = appContext.lastSyncDate
+            self?.syncState = .success
+
+            // Complicationを更新
+            self?.updateComplication(with: appContext.deliveries)
+
+            print("[WatchConnectivity] Loaded \(appContext.deliveries.count) deliveries from application context")
+        }
+    }
+
+    /// Complicationのデータを更新
+    private func updateComplication(with deliveries: [WatchDeliveryData]) {
+        ComplicationDataManager.shared.saveDeliveries(deliveries)
+        ComplicationDataManager.shared.reloadComplications()
+    }
+
+    /// 配達データレスポンスの処理
+    private func handleDeliveriesResponse(_ reply: [String: Any]) {
+        guard let typeString = reply["type"] as? String,
+              let messageType = WatchMessageType(rawValue: typeString) else {
+            DispatchQueue.main.async { [weak self] in
+                self?.errorMessage = "Invalid response type"
+                self?.syncState = .error("Invalid response type")
+            }
+            return
+        }
+
+        switch messageType {
+        case .allDeliveriesResponse, .statusRefreshComplete:
+            guard let payload = reply["payload"] as? Data else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.errorMessage = "No payload in response"
+                    self?.syncState = .error("No payload in response")
+                }
+                return
+            }
+
+            do {
+                let receivedDeliveries = try JSONDecoder().decode([WatchDeliveryData].self, from: payload)
+
+                DispatchQueue.main.async { [weak self] in
+                    self?.deliveries = receivedDeliveries
+                    self?.activeDeliveryCount = receivedDeliveries.filter { !$0.isDelivered }.count
+                    self?.deliveredCount = receivedDeliveries.filter { $0.isDelivered }.count
+                    self?.lastSyncDate = Date()
+                    self?.syncState = .success
+                    self?.errorMessage = nil
+
+                    // Complicationを更新
+                    self?.updateComplication(with: receivedDeliveries)
+
+                    print("[WatchConnectivity] Received \(receivedDeliveries.count) deliveries")
+                }
+            } catch {
+                DispatchQueue.main.async { [weak self] in
+                    print("[WatchConnectivity] Failed to decode deliveries: \(error)")
+                    self?.errorMessage = WatchSyncError.decodingFailed.localizedDescription
+                    self?.syncState = .error(WatchSyncError.decodingFailed.localizedDescription)
+                }
+            }
+
+        case .error:
+            let errorMsg = reply["error"] as? String ?? "Unknown error"
+            DispatchQueue.main.async { [weak self] in
+                self?.errorMessage = errorMsg
+                self?.syncState = .error(errorMsg)
+            }
+
+        default:
+            break
+        }
+    }
+
+    /// ステータス更新レスポンスの処理
+    private func handleRefreshResponse(_ reply: [String: Any]) {
+        handleDeliveriesResponse(reply)
+    }
+
+    /// 配達更新メッセージの処理
+    private func handleDeliveryUpdate(_ message: [String: Any]) {
+        guard let payload = message["payload"] as? Data else {
+            return
+        }
+
+        do {
+            let updatedDelivery = try JSONDecoder().decode(WatchDeliveryData.self, from: payload)
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+
+                // 既存の配達を更新または追加
+                if let index = self.deliveries.firstIndex(where: { $0.deliveryID == updatedDelivery.deliveryID }) {
+                    self.deliveries[index] = updatedDelivery
+                } else {
+                    self.deliveries.append(updatedDelivery)
+                }
+
+                // カウントを更新
+                self.activeDeliveryCount = self.deliveries.filter { !$0.isDelivered }.count
+                self.deliveredCount = self.deliveries.filter { $0.isDelivered }.count
+                self.lastSyncDate = Date()
+
+                print("[WatchConnectivity] Updated delivery: \(updatedDelivery.deliveryID)")
+            }
+        } catch {
+            print("[WatchConnectivity] Failed to decode delivery update: \(error)")
+        }
+    }
+
+    /// 配達削除メッセージの処理
+    private func handleDeliveryDeleted(_ message: [String: Any]) {
+        guard let deliveryID = message["deliveryID"] as? Int else {
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.deliveries.removeAll { $0.deliveryID == deliveryID }
+
+            // カウントを更新
+            self.activeDeliveryCount = self.deliveries.filter { !$0.isDelivered }.count
+            self.deliveredCount = self.deliveries.filter { $0.isDelivered }.count
+            self.lastSyncDate = Date()
+
+            print("[WatchConnectivity] Deleted delivery: \(deliveryID)")
+        }
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchConnectivityManager: WCSessionDelegate {
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async { [weak self] in
+            if let error = error {
+                print("[WatchConnectivity] Activation failed: \(error)")
+                self?.errorMessage = error.localizedDescription
+                self?.syncState = .error(error.localizedDescription)
+                return
+            }
+
+            print("[WatchConnectivity] Watch session activated with state: \(activationState.rawValue)")
+
+            self?.isPhoneReachable = session.isReachable
+
+            // アクティベート完了後、Application Contextからデータを読み込み
+            self?.loadFromApplicationContext()
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async { [weak self] in
+            self?.isPhoneReachable = session.isReachable
+
+            print("[WatchConnectivity] Phone reachability changed: \(session.isReachable)")
+
+            // iPhoneがリーチャブルになったら自動で同期リクエスト
+            if session.isReachable {
+                self?.requestAllDeliveries()
+            }
+        }
+    }
+
+    // メッセージ受信（リプライハンドラーあり）
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
+        print("[WatchConnectivity] Received message with reply handler")
+
+        // 受信確認を返す
+        replyHandler(["received": true, "timestamp": Date().timeIntervalSince1970])
+
+        processReceivedMessage(message)
+    }
+
+    // メッセージ受信（リプライハンドラーなし）
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        print("[WatchConnectivity] Received message without reply handler")
+        processReceivedMessage(message)
+    }
+
+    // Application Context受信
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        print("[WatchConnectivity] Received application context")
+
+        guard let appContext = WatchApplicationContext(dictionary: applicationContext) else {
+            print("[WatchConnectivity] Failed to parse application context")
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.deliveries = appContext.deliveries
+            self?.activeDeliveryCount = appContext.activeDeliveryCount
+            self?.deliveredCount = appContext.deliveredCount
+            self?.lastSyncDate = appContext.lastSyncDate
+            self?.syncState = .success
+
+            // Complicationを更新
+            self?.updateComplication(with: appContext.deliveries)
+
+            print("[WatchConnectivity] Updated from application context: \(appContext.deliveries.count) deliveries")
+        }
+    }
+
+    // MARK: - Private Helper
+
+    /// 受信メッセージの処理
+    private func processReceivedMessage(_ message: [String: Any]) {
+        guard let typeString = message["type"] as? String,
+              let messageType = WatchMessageType(rawValue: typeString) else {
+            return
+        }
+
+        switch messageType {
+        case .allDeliveriesResponse:
+            handleDeliveriesResponse(message)
+
+        case .deliveryUpdate:
+            handleDeliveryUpdate(message)
+
+        case .deliveryDeleted:
+            handleDeliveryDeleted(message)
+
+        case .statusRefreshComplete:
+            handleRefreshResponse(message)
+
+        case .heartbeat:
+            print("[WatchConnectivity] Heartbeat received from iOS")
+
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension WatchConnectivityManager {
+
+    /// アクティブな配達のみを取得
+    var activeDeliveries: [WatchDeliveryData] {
+        deliveries.filter { !$0.isDelivered }
+    }
+
+    /// 配達完了した配達のみを取得
+    var completedDeliveries: [WatchDeliveryData] {
+        deliveries.filter { $0.isDelivered }
+    }
+
+    /// 同期が必要か判定
+    var needsSync: Bool {
+        guard let lastSync = lastSyncDate else { return true }
+        // 5分以上経過していたら同期が必要
+        return Date().timeIntervalSince(lastSync) > 300
+    }
+
+    /// フォーマット済みの最終同期日時
+    var formattedLastSyncDate: String {
+        guard let date = lastSyncDate else { return "未同期" }
+
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/BlackCatWatch/Views/WatchDeliveryDetailView.swift
+++ b/BlackCatWatch/Views/WatchDeliveryDetailView.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+
+// MARK: - Watch Delivery Detail View
+/// watchOS向けの配達詳細画面
+/// タイムライン形式でステータス履歴を表示
+struct WatchDeliveryDetailView: View {
+    let deliveryData: WatchDeliveryData
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                // ヘッダーカード
+                headerCard
+                    .padding(.bottom, 16)
+            }
+            .padding(.horizontal, 8)
+        }
+        .navigationTitle("詳細")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(Color(hex: "0x1A1A2E"))
+    }
+
+    // MARK: - Header Card
+    private var headerCard: some View {
+        VStack(spacing: 12) {
+            // ステータスアイコンと状態
+            HStack(spacing: 10) {
+                statusIconView
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(deliveryData.latestStatus)
+                        .font(.system(.headline, design: .rounded))
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+
+                    Text("\(deliveryData.latestDate) \(deliveryData.latestTime ?? "")")
+                        .font(.caption2)
+                        .foregroundColor(Color(hex: "0xc0c0c0"))
+                }
+
+                Spacer()
+            }
+
+            Divider()
+                .background(Color(hex: "0x606060"))
+
+            // 配送業者と伝票番号
+            VStack(spacing: 8) {
+                // 配送業者
+                HStack {
+                    Image(systemName: deliveryData.carrierIcon)
+                        .font(.caption2)
+                        .foregroundColor(Color(hex: "0x4A90D9"))
+
+                    Text(deliveryData.carrierName)
+                        .font(.caption)
+                        .foregroundColor(Color(hex: "0xc0c0c0"))
+
+                    Spacer()
+                }
+
+                // 伝票番号
+                HStack {
+                    Image(systemName: "barcode")
+                        .font(.caption2)
+                        .foregroundColor(Color(hex: "0x808080"))
+
+                    Text(String(deliveryData.deliveryID))
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundColor(Color(hex: "0xc0c0c0"))
+
+                    Spacer()
+                }
+
+                // 場所
+                if !deliveryData.latestLocation.isEmpty {
+                    HStack {
+                        Image(systemName: "mappin.and.ellipse")
+                            .font(.caption2)
+                            .foregroundColor(Color(hex: "0x808080"))
+
+                        Text(deliveryData.latestLocation)
+                            .font(.caption)
+                            .foregroundColor(Color(hex: "0xc0c0c0"))
+
+                        Spacer()
+                    }
+                }
+            }
+
+            // 進捗バー
+            progressBar
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(hex: "0x0F3460"))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(deliveryData.statusColor.opacity(0.4), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(headerAccessibilityLabel)
+    }
+
+    // MARK: - Status Icon View
+    private var statusIconView: some View {
+        ZStack {
+            Circle()
+                .fill(deliveryData.statusColor.opacity(0.2))
+                .frame(width: 44, height: 44)
+
+            Circle()
+                .fill(deliveryData.statusColor)
+                .frame(width: 36, height: 36)
+
+            Image(systemName: deliveryData.statusIcon)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundColor(.white)
+        }
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Progress Bar
+    private var progressBar: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("進捗")
+                    .font(.caption2)
+                    .foregroundColor(Color(hex: "0x808080"))
+
+                Spacer()
+
+                Text("\(deliveryData.progressPercentage)%")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(deliveryData.statusColor)
+            }
+
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color(hex: "0x404040"))
+                        .frame(height: 4)
+
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(deliveryData.statusColor)
+                        .frame(width: geometry.size.width * CGFloat(deliveryData.progressPercentage) / 100, height: 4)
+                }
+            }
+            .frame(height: 4)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("進捗 \(deliveryData.progressPercentage)パーセント")
+    }
+
+    // MARK: - Computed Properties
+    private var headerAccessibilityLabel: String {
+        let status = deliveryData.latestStatus
+        let carrier = deliveryData.carrierName
+        let trackingNumber = "伝票番号 \(deliveryData.deliveryID)"
+        let progress = "進捗 \(deliveryData.progressPercentage)パーセント"
+        return "\(status)、\(carrier)、\(trackingNumber)、\(progress)"
+    }
+}
+
+// MARK: - Preview
+#if DEBUG
+struct WatchDeliveryDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            WatchDeliveryDetailView(
+                deliveryData: WatchDeliveryData(
+                    id: "preview-123",
+                    deliveryID: 123456789012,
+                    carrierName: "ヤマト運輸",
+                    carrierIcon: "shippingbox.fill",
+                    latestStatus: "配達中",
+                    latestStatusType: "delivering",
+                    latestDate: "01/29",
+                    latestTime: "14:30",
+                    latestLocation: "配送センター",
+                    registeredDate: Date(),
+                    isDelivered: false
+                )
+            )
+        }
+        .previewDevice("Apple Watch Series 9 - 45mm")
+    }
+}
+#endif

--- a/BlackCatWatch/Views/WatchDeliveryListView.swift
+++ b/BlackCatWatch/Views/WatchDeliveryListView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+// MARK: - Watch Delivery List View
+/// watchOS向けの配達リスト画面
+/// Digital Crownでのスクロール、プルリフレッシュに対応
+struct WatchDeliveryListView: View {
+    @StateObject private var viewModel = WatchDeliveryViewModel()
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.isLoading {
+                    WatchLoadingView()
+                } else if viewModel.deliveries.isEmpty {
+                    WatchEmptyStateView()
+                } else {
+                    deliveryListContent
+                }
+            }
+            .navigationTitle("配達状況")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .onAppear {
+            viewModel.loadDeliveries()
+        }
+    }
+
+    // MARK: - Delivery List Content
+    private var deliveryListContent: some View {
+        List {
+            ForEach(viewModel.deliveries) { item in
+                NavigationLink(destination: WatchDeliveryDetailView(deliveryData: item)) {
+                    WatchDeliveryRowView(deliveryData: item)
+                }
+                .listRowBackground(Color(hex: "0x0F3460"))
+            }
+        }
+        .listStyle(.carousel)
+        .refreshable {
+            viewModel.refreshStatus()
+        }
+    }
+}
+
+// MARK: - Watch Delivery Row View
+/// 配達リストの各行を表示するView
+struct WatchDeliveryRowView: View {
+    let deliveryData: WatchDeliveryData
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // ステータスアイコン
+            statusIcon
+
+            // 情報
+            VStack(alignment: .leading, spacing: 4) {
+                // 伝票番号
+                Text(String(deliveryData.deliveryID))
+                    .font(.system(.headline, design: .monospaced))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+
+                // ステータス
+                Text(deliveryData.latestStatus)
+                    .font(.caption2)
+                    .foregroundColor(deliveryData.statusColor)
+                    .lineLimit(1)
+
+                // 配送業者
+                Text(deliveryData.carrierName)
+                    .font(.caption2)
+                    .foregroundColor(Color(hex: "0xa0a0a0"))
+                    .lineLimit(1)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("詳細を表示するにはダブルタップ")
+    }
+
+    // MARK: - Status Icon
+    private var statusIcon: some View {
+        ZStack {
+            Circle()
+                .fill(deliveryData.statusColor.opacity(0.2))
+                .frame(width: 36, height: 36)
+
+            Circle()
+                .fill(deliveryData.statusColor)
+                .frame(width: 28, height: 28)
+
+            Image(systemName: deliveryData.statusIcon)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundColor(.white)
+        }
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Computed Properties
+    private var accessibilityLabel: String {
+        let trackingNumber = "伝票番号 \(deliveryData.deliveryID)"
+        let carrier = deliveryData.carrierName
+        let status = deliveryData.latestStatus
+        return "\(trackingNumber)、\(carrier)、\(status)"
+    }
+}
+
+// MARK: - Watch Loading View
+/// watchOS向けの読み込み中表示
+struct WatchLoadingView: View {
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle(tint: Color(hex: "0xFF9F43")))
+                .scaleEffect(1.5)
+
+            Text("読み込み中...")
+                .font(.caption)
+                .foregroundColor(Color(hex: "0xa0a0a0"))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(hex: "0x1A1A2E"))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("読み込み中")
+    }
+}
+
+// MARK: - Watch Empty State View
+/// watchOS向けの空状態表示
+struct WatchEmptyStateView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "shippingbox")
+                .font(.system(size: 32))
+                .foregroundColor(Color(hex: "0x808080"))
+                .accessibilityHidden(true)
+
+            Text("荷物がありません")
+                .font(.headline)
+                .foregroundColor(.white)
+                .multilineTextAlignment(.center)
+
+            Text("iPhoneアプリで\n追加してください")
+                .font(.caption2)
+                .foregroundColor(Color(hex: "0xa0a0a0"))
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(hex: "0x1A1A2E"))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("荷物がありません。iPhoneアプリで追加してください")
+    }
+}
+
+// MARK: - Color Extension for Watch
+extension Color {
+    init(hex: String) {
+        var color: UInt64 = 0
+        var r: Double = 0, g: Double = 0, b: Double = 0
+        if Scanner(string: hex.replacingOccurrences(of: "#", with: "")).scanHexInt64(&color) {
+            r = Double((color & 0xFF0000) >> 16) / 255.0
+            g = Double((color & 0x00FF00) >>  8) / 255.0
+            b = Double( color & 0x0000FF       ) / 255.0
+        }
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+// MARK: - Preview
+#if DEBUG
+struct WatchDeliveryListView_Previews: PreviewProvider {
+    static var previews: some View {
+        WatchDeliveryListView()
+            .previewDevice("Apple Watch Series 9 - 45mm")
+    }
+}
+#endif

--- a/BlackCatWatch/WatchDeliveryViewModel.swift
+++ b/BlackCatWatch/WatchDeliveryViewModel.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import Combine
+
+/// Apple Watch用の配達情報ViewModel
+/// WatchConnectivityManagerと統合してiOSアプリからデータを同期
+@MainActor
+final class WatchDeliveryViewModel: ObservableObject {
+
+    // MARK: - Published Properties
+
+    /// 配達データ（WatchDeliveryDataを使用）
+    @Published var deliveries: [WatchDeliveryData] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    // MARK: - Private Properties
+
+    private let connectivityManager = WatchConnectivityManager.shared
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Computed Properties
+
+    /// アクティブな配達（配達完了以外）
+    var activeDeliveries: [WatchDeliveryData] {
+        deliveries.filter { !$0.isDelivered }
+    }
+
+    /// 配達完了した配達
+    var completedDeliveries: [WatchDeliveryData] {
+        deliveries.filter { $0.isDelivered }
+    }
+
+    /// アクティブな配達数
+    var activeDeliveryCount: Int {
+        activeDeliveries.count
+    }
+
+    /// 最終同期日時（フォーマット済み）
+    var formattedLastSyncDate: String {
+        connectivityManager.formattedLastSyncDate
+    }
+
+    /// iPhoneがリーチャブルか
+    var isPhoneReachable: Bool {
+        connectivityManager.isPhoneReachable
+    }
+
+    // MARK: - Initialization
+
+    init() {
+        setupBindings()
+    }
+
+    // MARK: - Setup
+
+    /// WatchConnectivityManagerとのバインディングを設定
+    private func setupBindings() {
+        // 配達データの購読
+        connectivityManager.$deliveries
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] deliveries in
+                self?.deliveries = deliveries
+            }
+            .store(in: &cancellables)
+
+        // 同期状態の購読
+        connectivityManager.$syncState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                switch state {
+                case .idle, .success:
+                    self?.isLoading = false
+                    self?.errorMessage = nil
+                case .syncing:
+                    self?.isLoading = true
+                    self?.errorMessage = nil
+                case .error(let message):
+                    self?.isLoading = false
+                    self?.errorMessage = message
+                }
+            }
+            .store(in: &cancellables)
+
+        // エラーメッセージの購読
+        connectivityManager.$errorMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                self?.errorMessage = message
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Public Methods
+
+    /// 配達データをiPhoneからリクエスト
+    func loadDeliveries() {
+        connectivityManager.requestAllDeliveries()
+    }
+
+    /// ステータス更新をリクエスト
+    func refreshStatus() {
+        connectivityManager.requestStatusRefresh()
+    }
+
+    /// キャッシュをクリア
+    func clearCache() {
+        connectivityManager.clearCache()
+    }
+}
+
+// MARK: - WatchDeliveryData Extension for UI
+
+extension WatchDeliveryData {
+    /// ステータスに応じた色
+    var statusColor: Color {
+        switch latestStatusType {
+        case "delivered":
+            return .green
+        case "delivering":
+            return .red
+        case "shipping":
+            return .orange
+        case "sended":
+            return .pink
+        case "received":
+            return .blue
+        default:
+            return .gray
+        }
+    }
+
+    /// ステータスに応じたアイコン
+    var statusIcon: String {
+        switch latestStatusType {
+        case "delivered":
+            return "checkmark.circle.fill"
+        case "delivering":
+            return "figure.walk"
+        case "shipping":
+            return "box.truck.fill"
+        case "sended":
+            return "paperplane.fill"
+        case "received":
+            return "arrow.down.doc.fill"
+        default:
+            return "questionmark.circle.fill"
+        }
+    }
+
+    /// 進捗パーセンテージ
+    var progressPercentage: Int {
+        switch latestStatusType {
+        case "received":
+            return 20
+        case "sended":
+            return 40
+        case "shipping":
+            return 60
+        case "delivering":
+            return 80
+        case "delivered":
+            return 100
+        default:
+            return 0
+        }
+    }
+}

--- a/Shared/SharedDataManager.swift
+++ b/Shared/SharedDataManager.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// App Groupを使用してiOS/watchOS間でデータを共有するマネージャー
+/// 両プラットフォームで共通で使用される
+public final class SharedDataManager {
+    public static let shared = SharedDataManager()
+
+    // MARK: - Constants
+
+    /// App Group識別子
+    public static let appGroupIdentifier = "group.com.blackcat.delivery"
+
+    /// 配達アイテムのキー
+    private let deliveryItemsKey = "SharedDeliveryItems"
+
+    /// 最終更新日時のキー
+    private let lastUpdateKey = "SharedLastUpdate"
+
+    // MARK: - Properties
+
+    private var sharedDefaults: UserDefaults? {
+        return UserDefaults(suiteName: SharedDataManager.appGroupIdentifier)
+    }
+
+    // MARK: - Initialization
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// 配達アイテムを保存する
+    /// - Parameter items: 保存する配達アイテムの配列
+    public func saveDeliveryItems(_ items: [SharedDeliveryItem]) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        do {
+            let encoded = try encoder.encode(items)
+            sharedDefaults?.set(encoded, forKey: deliveryItemsKey)
+            sharedDefaults?.set(Date(), forKey: lastUpdateKey)
+            sharedDefaults?.synchronize()
+        } catch {
+            print("[SharedDataManager] Failed to encode delivery items: \(error)")
+        }
+    }
+
+    /// 配達アイテムを読み込む
+    /// - Returns: 保存されている配達アイテムの配列
+    public func loadDeliveryItems() -> [SharedDeliveryItem] {
+        guard let data = sharedDefaults?.data(forKey: deliveryItemsKey) else {
+            return []
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        do {
+            let items = try decoder.decode([SharedDeliveryItem].self, from: data)
+            return items
+        } catch {
+            print("[SharedDataManager] Failed to decode delivery items: \(error)")
+            return []
+        }
+    }
+
+    /// 最終更新日時を取得する
+    /// - Returns: 最終更新日時（存在しない場合はnil）
+    public func lastUpdateDate() -> Date? {
+        return sharedDefaults?.object(forKey: lastUpdateKey) as? Date
+    }
+
+    /// すべての共有データをクリアする
+    public func clearAllData() {
+        sharedDefaults?.removeObject(forKey: deliveryItemsKey)
+        sharedDefaults?.removeObject(forKey: lastUpdateKey)
+        sharedDefaults?.synchronize()
+    }
+
+    /// 特定のアイテムを削除する
+    /// - Parameter id: 削除するアイテムのID
+    public func removeItem(withId id: UUID) {
+        var items = loadDeliveryItems()
+        items.removeAll { $0.id == id }
+        saveDeliveryItems(items)
+    }
+
+    /// アイテムを追加する
+    /// - Parameter item: 追加するアイテム
+    public func addItem(_ item: SharedDeliveryItem) {
+        var items = loadDeliveryItems()
+        items.append(item)
+        saveDeliveryItems(items)
+    }
+
+    /// アイテムを更新する
+    /// - Parameter item: 更新するアイテム
+    public func updateItem(_ item: SharedDeliveryItem) {
+        var items = loadDeliveryItems()
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index] = item
+            saveDeliveryItems(items)
+        }
+    }
+}
+
+// MARK: - Notification Names
+
+public extension Notification.Name {
+    /// 共有データが更新された時の通知
+    static let sharedDataDidUpdate = Notification.Name("sharedDataDidUpdate")
+}

--- a/Shared/SharedDeliveryItem.swift
+++ b/Shared/SharedDeliveryItem.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// iOS/watchOS間で共有する配達アイテムモデル
+/// App Groupを通じて両プラットフォームでデータを共有する
+public struct SharedDeliveryItem: Identifiable, Codable, Equatable {
+    public let id: UUID
+    public let trackingNumber: String
+    public let carrierType: SharedCarrierType
+    public let latestStatus: String
+    public let latestDate: String?
+    public let latestTime: String?
+    public let shopName: String?
+    public let statusType: SharedDeliveryStatusType
+    public let registeredDate: Date
+
+    public init(
+        id: UUID = UUID(),
+        trackingNumber: String,
+        carrierType: SharedCarrierType,
+        latestStatus: String,
+        latestDate: String? = nil,
+        latestTime: String? = nil,
+        shopName: String? = nil,
+        statusType: SharedDeliveryStatusType,
+        registeredDate: Date = Date()
+    ) {
+        self.id = id
+        self.trackingNumber = trackingNumber
+        self.carrierType = carrierType
+        self.latestStatus = latestStatus
+        self.latestDate = latestDate
+        self.latestTime = latestTime
+        self.shopName = shopName
+        self.statusType = statusType
+        self.registeredDate = registeredDate
+    }
+}
+
+// MARK: - Shared Carrier Type
+
+/// 配送業者タイプ（共有用）
+public enum SharedCarrierType: String, Codable, CaseIterable {
+    case yamato = "yamato"
+    case sagawa = "sagawa"
+    case japanPost = "japanPost"
+
+    public var displayName: String {
+        switch self {
+        case .yamato:
+            return "ヤマト運輸"
+        case .sagawa:
+            return "佐川急便"
+        case .japanPost:
+            return "日本郵便"
+        }
+    }
+
+    public var iconName: String {
+        switch self {
+        case .yamato:
+            return "shippingbox.fill"
+        case .sagawa:
+            return "truck.box.fill"
+        case .japanPost:
+            return "envelope.fill"
+        }
+    }
+}
+
+// MARK: - Shared Delivery Status Type
+
+/// 配達ステータスタイプ（共有用）
+public enum SharedDeliveryStatusType: String, Codable {
+    case received = "received"
+    case sended = "sended"
+    case shipping = "shipping"
+    case delivering = "delivering"
+    case delivered = "delivered"
+    case unknown = "unknown"
+
+    /// ステータス文字列から変換
+    public static func from(status: String) -> SharedDeliveryStatusType {
+        switch status {
+        case "荷物受付":
+            return .received
+        case "発送済み":
+            return .sended
+        case "輸送中":
+            return .shipping
+        case "配達中", "持戻（ご不在）", "配達日・時間帯指定（保管中）":
+            return .delivering
+        case "配達完了", "配達完了（宅配ボックス）":
+            return .delivered
+        default:
+            return .unknown
+        }
+    }
+}

--- a/Shared/WatchDeliveryData.swift
+++ b/Shared/WatchDeliveryData.swift
@@ -1,0 +1,260 @@
+//
+//  WatchDeliveryData.swift
+//  BlackCat
+//
+//  Apple Watch用の軽量配達データモデル
+//  iOSとwatchOS間でのデータ同期に使用
+//
+
+import Foundation
+
+// MARK: - Watch用配達データモデル
+
+/// Apple Watch向けの軽量な配達情報
+/// Codableプロトコルに対応し、WatchConnectivityでの転送に最適化
+struct WatchDeliveryData: Codable, Identifiable, Equatable {
+    let id: String
+    let deliveryID: Int
+    let carrierName: String
+    let carrierIcon: String
+    let latestStatus: String
+    let latestStatusType: String
+    let latestDate: String
+    let latestTime: String?
+    let latestLocation: String
+    let registeredDate: Date
+    let isDelivered: Bool
+
+    /// メンバーワイズイニシャライザ
+    init(
+        id: String,
+        deliveryID: Int,
+        carrierName: String,
+        carrierIcon: String,
+        latestStatus: String,
+        latestStatusType: String,
+        latestDate: String,
+        latestTime: String?,
+        latestLocation: String,
+        registeredDate: Date,
+        isDelivered: Bool
+    ) {
+        self.id = id
+        self.deliveryID = deliveryID
+        self.carrierName = carrierName
+        self.carrierIcon = carrierIcon
+        self.latestStatus = latestStatus
+        self.latestStatusType = latestStatusType
+        self.latestDate = latestDate
+        self.latestTime = latestTime
+        self.latestLocation = latestLocation
+        self.registeredDate = registeredDate
+        self.isDelivered = isDelivered
+    }
+
+    /// ディクショナリからの初期化
+    init?(dictionary: [String: Any]) {
+        guard let id = dictionary["id"] as? String,
+              let deliveryID = dictionary["deliveryID"] as? Int,
+              let carrierName = dictionary["carrierName"] as? String,
+              let carrierIcon = dictionary["carrierIcon"] as? String,
+              let latestStatus = dictionary["latestStatus"] as? String,
+              let latestStatusType = dictionary["latestStatusType"] as? String,
+              let latestDate = dictionary["latestDate"] as? String,
+              let latestLocation = dictionary["latestLocation"] as? String,
+              let registeredTimestamp = dictionary["registeredDate"] as? TimeInterval,
+              let isDelivered = dictionary["isDelivered"] as? Bool else {
+            return nil
+        }
+
+        self.id = id
+        self.deliveryID = deliveryID
+        self.carrierName = carrierName
+        self.carrierIcon = carrierIcon
+        self.latestStatus = latestStatus
+        self.latestStatusType = latestStatusType
+        self.latestDate = latestDate
+        self.latestTime = dictionary["latestTime"] as? String
+        self.latestLocation = latestLocation
+        self.registeredDate = Date(timeIntervalSince1970: registeredTimestamp)
+        self.isDelivered = isDelivered
+    }
+
+    /// ディクショナリへの変換
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": id,
+            "deliveryID": deliveryID,
+            "carrierName": carrierName,
+            "carrierIcon": carrierIcon,
+            "latestStatus": latestStatus,
+            "latestStatusType": latestStatusType,
+            "latestDate": latestDate,
+            "latestLocation": latestLocation,
+            "registeredDate": registeredDate.timeIntervalSince1970,
+            "isDelivered": isDelivered
+        ]
+
+        if let latestTime = latestTime {
+            dict["latestTime"] = latestTime
+        }
+
+        return dict
+    }
+}
+
+// MARK: - Watch同期メッセージタイプ
+
+/// iOS-Watch間の通信メッセージタイプ
+enum WatchMessageType: String, Codable {
+    /// 全配達データのリクエスト
+    case requestAllDeliveries = "request_all_deliveries"
+    /// 全配達データの応答
+    case allDeliveriesResponse = "all_deliveries_response"
+    /// 単一配達の更新
+    case deliveryUpdate = "delivery_update"
+    /// 配達データの削除
+    case deliveryDeleted = "delivery_deleted"
+    /// ステータス更新リクエスト
+    case requestStatusRefresh = "request_status_refresh"
+    /// ステータス更新完了通知
+    case statusRefreshComplete = "status_refresh_complete"
+    /// エラー通知
+    case error = "error"
+    /// ハートビート（接続確認）
+    case heartbeat = "heartbeat"
+}
+
+// MARK: - Watch同期メッセージ
+
+/// iOS-Watch間で交換するメッセージ
+struct WatchSyncMessage: Codable {
+    let type: WatchMessageType
+    let timestamp: Date
+    let payload: Data?
+
+    init(type: WatchMessageType, payload: Data? = nil) {
+        self.type = type
+        self.timestamp = Date()
+        self.payload = payload
+    }
+
+    /// ディクショナリからの初期化
+    init?(dictionary: [String: Any]) {
+        guard let typeString = dictionary["type"] as? String,
+              let type = WatchMessageType(rawValue: typeString),
+              let timestamp = dictionary["timestamp"] as? TimeInterval else {
+            return nil
+        }
+
+        self.type = type
+        self.timestamp = Date(timeIntervalSince1970: timestamp)
+        self.payload = dictionary["payload"] as? Data
+    }
+
+    /// ディクショナリへの変換
+    func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "type": type.rawValue,
+            "timestamp": timestamp.timeIntervalSince1970
+        ]
+
+        if let payload = payload {
+            dict["payload"] = payload
+        }
+
+        return dict
+    }
+}
+
+// MARK: - 同期エラー
+
+/// Watch同期に関するエラー
+enum WatchSyncError: Error, LocalizedError {
+    case sessionNotSupported
+    case sessionNotActivated
+    case watchNotReachable
+    case encodingFailed
+    case decodingFailed
+    case transferFailed(String)
+    case timeout
+    case unknown(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .sessionNotSupported:
+            return "このデバイスはWatch Connectivityをサポートしていません"
+        case .sessionNotActivated:
+            return "Watch Connectivityセッションがアクティブではありません"
+        case .watchNotReachable:
+            return "Apple Watchに接続できません"
+        case .encodingFailed:
+            return "データのエンコードに失敗しました"
+        case .decodingFailed:
+            return "データのデコードに失敗しました"
+        case .transferFailed(let message):
+            return "データ転送に失敗しました: \(message)"
+        case .timeout:
+            return "通信がタイムアウトしました"
+        case .unknown(let message):
+            return "不明なエラー: \(message)"
+        }
+    }
+}
+
+// MARK: - 同期状態
+
+/// Watch同期の状態
+enum WatchSyncState: Equatable {
+    case idle
+    case syncing
+    case success
+    case error(String)
+
+    var isSyncing: Bool {
+        if case .syncing = self { return true }
+        return false
+    }
+}
+
+// MARK: - ユーザーコンテキスト
+
+/// バックグラウンドで同期されるアプリケーションコンテキスト
+struct WatchApplicationContext: Codable {
+    let lastSyncDate: Date
+    let activeDeliveryCount: Int
+    let deliveredCount: Int
+    let deliveries: [WatchDeliveryData]
+
+    /// ディクショナリへの変換
+    func toDictionary() -> [String: Any] {
+        return [
+            "lastSyncDate": lastSyncDate.timeIntervalSince1970,
+            "activeDeliveryCount": activeDeliveryCount,
+            "deliveredCount": deliveredCount,
+            "deliveries": deliveries.map { $0.toDictionary() }
+        ]
+    }
+
+    /// ディクショナリからの初期化
+    init?(dictionary: [String: Any]) {
+        guard let lastSyncTimestamp = dictionary["lastSyncDate"] as? TimeInterval,
+              let activeDeliveryCount = dictionary["activeDeliveryCount"] as? Int,
+              let deliveredCount = dictionary["deliveredCount"] as? Int,
+              let deliveriesArray = dictionary["deliveries"] as? [[String: Any]] else {
+            return nil
+        }
+
+        self.lastSyncDate = Date(timeIntervalSince1970: lastSyncTimestamp)
+        self.activeDeliveryCount = activeDeliveryCount
+        self.deliveredCount = deliveredCount
+        self.deliveries = deliveriesArray.compactMap { WatchDeliveryData(dictionary: $0) }
+    }
+
+    init(lastSyncDate: Date, activeDeliveryCount: Int, deliveredCount: Int, deliveries: [WatchDeliveryData]) {
+        self.lastSyncDate = lastSyncDate
+        self.activeDeliveryCount = activeDeliveryCount
+        self.deliveredCount = deliveredCount
+        self.deliveries = deliveries
+    }
+}


### PR DESCRIPTION
## Summary
BlackCatアプリにApple Watchサポートを追加しました。

### 新機能
- **watchOSアプリ**: 配達リスト・詳細画面をSwiftUIで実装
- **Complication（文字盤）**: 配達状況をWatch文字盤に表示
- **リアルタイム同期**: WatchConnectivityによるiOS-Watch間データ同期
- **App Group**: バックグラウンドでのデータ共有

### ファイル構成
```
BlackCatWatch/
├── BlackCatWatchApp.swift
├── ContentView.swift
├── WatchDeliveryViewModel.swift
├── Utils/WatchConnectivityManager.swift
├── Views/
├── Complications/
└── Assets.xcassets/

Shared/
├── WatchDeliveryData.swift
├── SharedDeliveryItem.swift
└── SharedDataManager.swift
```

### 対応するComplication
- accessoryCircular
- accessoryRectangular
- accessoryInline
- accessoryCorner

## Test plan
- [ ] watchOSアプリのビルド確認
- [ ] 配達リスト表示確認
- [ ] 配達詳細表示確認
- [ ] iOS-Watch間同期確認
- [ ] Complication表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)