### PR TITLE
chore: Bump build number to 8 for all targets

### DIFF
--- a/BlackCarWidget/Info.plist
+++ b/BlackCarWidget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/BlackCat/Info.plist
+++ b/BlackCat/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>

--- a/BlackCatWatch/Complications/Info.plist
+++ b/BlackCatWatch/Complications/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.2.0</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>8</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/BlackCatWatch/Info.plist
+++ b/BlackCatWatch/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>8</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Domain/Info.plist
+++ b/Domain/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 </dict>
 </plist>

--- a/DomainTests/Info.plist
+++ b/DomainTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Increment build number to 8 across all targets for v2.0.0 release

## Changes
- `BlackCat/Info.plist`: 7 → 8
- `Domain/Info.plist`: 7 → 8
- `DomainTests/Info.plist`: 7 → 8
- `BlackCarWidget/Info.plist`: 7 → 8
- `BlackCatWatch/Info.plist`: 1 → 8
- `BlackCatWatch/Complications/Info.plist`: 1 → 8