### PR TITLE
fix: Resolve Int overflow on watchOS arm64_32 in sample data

### DIFF
--- a/BlackCat/Utils/WatchConnectivityManager.swift
+++ b/BlackCat/Utils/WatchConnectivityManager.swift
@@ -165,7 +165,7 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
 
     /// 配達削除通知を送信
     /// - Parameter deliveryID: 削除された配達ID
-    func sendDeliveryDeleted(deliveryID: Int) {
+    func sendDeliveryDeleted(deliveryID: String) {
         guard let session = session,
               session.activationState == .activated else {
             return
@@ -436,7 +436,7 @@ extension WatchDeliveryData {
     /// 注: この初期化子はiOSアプリ側でのみ使用
     init(from item: DeliveryItem, carrier: DeliveryCarrier) {
         self.id = item.id.uuidString
-        self.deliveryID = item.deliveryID
+        self.deliveryID = String(item.deliveryID)
         self.carrierName = carrier.displayName
         self.carrierIcon = carrier.iconName
         self.latestStatus = item.latestStatus?.status ?? "不明"

--- a/BlackCatWatch/Complications/ComplicationController.swift
+++ b/BlackCatWatch/Complications/ComplicationController.swift
@@ -27,7 +27,7 @@ struct WatchComplicationEntry: TimelineEntry {
             deliveries: [
                 WatchDeliveryData(
                     id: UUID().uuidString,
-                    deliveryID: 123456789012,
+                    deliveryID: 1234567890,
                     carrierName: "ヤマト運輸",
                     carrierIcon: "shippingbox.fill",
                     latestStatus: "配達中",
@@ -57,7 +57,7 @@ struct WatchComplicationEntry: TimelineEntry {
             deliveries: [
                 WatchDeliveryData(
                     id: UUID().uuidString,
-                    deliveryID: 123456789012,
+                    deliveryID: 1234567890,
                     carrierName: "ヤマト運輸",
                     carrierIcon: "shippingbox.fill",
                     latestStatus: "配達中",
@@ -70,7 +70,7 @@ struct WatchComplicationEntry: TimelineEntry {
                 ),
                 WatchDeliveryData(
                     id: UUID().uuidString,
-                    deliveryID: 987654321098,
+                    deliveryID: 987654321,
                     carrierName: "佐川急便",
                     carrierIcon: "truck.box.fill",
                     latestStatus: "輸送中",

--- a/BlackCatWatch/Complications/ComplicationController.swift
+++ b/BlackCatWatch/Complications/ComplicationController.swift
@@ -27,7 +27,7 @@ struct WatchComplicationEntry: TimelineEntry {
             deliveries: [
                 WatchDeliveryData(
                     id: UUID().uuidString,
-                    deliveryID: 1234567890,
+                    deliveryID: "123456789012",
                     carrierName: "ヤマト運輸",
                     carrierIcon: "shippingbox.fill",
                     latestStatus: "配達中",
@@ -57,7 +57,7 @@ struct WatchComplicationEntry: TimelineEntry {
             deliveries: [
                 WatchDeliveryData(
                     id: UUID().uuidString,
-                    deliveryID: 1234567890,
+                    deliveryID: "123456789012",
                     carrierName: "ヤマト運輸",
                     carrierIcon: "shippingbox.fill",
                     latestStatus: "配達中",
@@ -70,7 +70,7 @@ struct WatchComplicationEntry: TimelineEntry {
                 ),
                 WatchDeliveryData(
                     id: UUID().uuidString,
-                    deliveryID: 987654321,
+                    deliveryID: "987654321098",
                     carrierName: "佐川急便",
                     carrierIcon: "truck.box.fill",
                     latestStatus: "輸送中",
@@ -146,7 +146,7 @@ extension WatchDeliveryData {
 
     /// 伝票番号（文字列形式）
     var trackingNumberString: String {
-        String(deliveryID)
+        deliveryID
     }
 }
 

--- a/BlackCatWatch/ContentView.swift
+++ b/BlackCatWatch/ContentView.swift
@@ -187,7 +187,7 @@ struct DeliveryDetailView: View {
                         .font(.caption2)
                         .foregroundColor(.secondary)
 
-                    Text(String(delivery.deliveryID))
+                    Text(delivery.deliveryID)
                         .font(.caption)
                         .fontDesign(.monospaced)
                 }

--- a/BlackCatWatch/Utils/WatchConnectivityManager.swift
+++ b/BlackCatWatch/Utils/WatchConnectivityManager.swift
@@ -302,7 +302,7 @@ final class WatchConnectivityManager: NSObject, ObservableObject {
 
     /// 配達削除メッセージの処理
     private func handleDeliveryDeleted(_ message: [String: Any]) {
-        guard let deliveryID = message["deliveryID"] as? Int else {
+        guard let deliveryID = message["deliveryID"] as? String else {
             return
         }
 

--- a/BlackCatWatch/Views/WatchDeliveryDetailView.swift
+++ b/BlackCatWatch/Views/WatchDeliveryDetailView.swift
@@ -174,7 +174,7 @@ struct WatchDeliveryDetailView_Previews: PreviewProvider {
             WatchDeliveryDetailView(
                 deliveryData: WatchDeliveryData(
                     id: "preview-123",
-                    deliveryID: 123456789012,
+                    deliveryID: 1234567890,
                     carrierName: "ヤマト運輸",
                     carrierIcon: "shippingbox.fill",
                     latestStatus: "配達中",

--- a/BlackCatWatch/Views/WatchDeliveryDetailView.swift
+++ b/BlackCatWatch/Views/WatchDeliveryDetailView.swift
@@ -66,7 +66,7 @@ struct WatchDeliveryDetailView: View {
                         .font(.caption2)
                         .foregroundColor(Color(hex: "0x808080"))
 
-                    Text(String(deliveryData.deliveryID))
+                    Text(deliveryData.deliveryID)
                         .font(.system(.caption, design: .monospaced))
                         .foregroundColor(Color(hex: "0xc0c0c0"))
 
@@ -174,7 +174,7 @@ struct WatchDeliveryDetailView_Previews: PreviewProvider {
             WatchDeliveryDetailView(
                 deliveryData: WatchDeliveryData(
                     id: "preview-123",
-                    deliveryID: 1234567890,
+                    deliveryID: "123456789012",
                     carrierName: "ヤマト運輸",
                     carrierIcon: "shippingbox.fill",
                     latestStatus: "配達中",

--- a/BlackCatWatch/Views/WatchDeliveryListView.swift
+++ b/BlackCatWatch/Views/WatchDeliveryListView.swift
@@ -55,7 +55,7 @@ struct WatchDeliveryRowView: View {
             // 情報
             VStack(alignment: .leading, spacing: 4) {
                 // 伝票番号
-                Text(String(deliveryData.deliveryID))
+                Text(deliveryData.deliveryID)
                     .font(.system(.headline, design: .monospaced))
                     .foregroundColor(.white)
                     .lineLimit(1)

--- a/BlackCatWatch/WatchDeliveryItem.swift
+++ b/BlackCatWatch/WatchDeliveryItem.swift
@@ -23,7 +23,7 @@ struct WatchDeliveryItem: Identifiable, Equatable {
 
     // MARK: - Convenience Properties
 
-    var deliveryID: Int { deliveryData.deliveryID }
+    var deliveryID: String { deliveryData.deliveryID }
     var carrierName: String { deliveryData.carrierName }
     var latestStatus: String { deliveryData.latestStatus }
     var latestDate: String { deliveryData.latestDate }
@@ -34,7 +34,7 @@ struct WatchDeliveryItem: Identifiable, Equatable {
 
     /// 伝票番号の文字列表現
     var trackingNumberString: String {
-        String(deliveryData.deliveryID)
+        deliveryData.deliveryID
     }
 
     /// 日時のフォーマット済み表示

--- a/Shared/WatchDeliveryData.swift
+++ b/Shared/WatchDeliveryData.swift
@@ -14,7 +14,7 @@ import Foundation
 /// Codableプロトコルに対応し、WatchConnectivityでの転送に最適化
 struct WatchDeliveryData: Codable, Identifiable, Equatable {
     let id: String
-    let deliveryID: Int
+    let deliveryID: String
     let carrierName: String
     let carrierIcon: String
     let latestStatus: String
@@ -28,7 +28,7 @@ struct WatchDeliveryData: Codable, Identifiable, Equatable {
     /// メンバーワイズイニシャライザ
     init(
         id: String,
-        deliveryID: Int,
+        deliveryID: String,
         carrierName: String,
         carrierIcon: String,
         latestStatus: String,
@@ -55,7 +55,7 @@ struct WatchDeliveryData: Codable, Identifiable, Equatable {
     /// ディクショナリからの初期化
     init?(dictionary: [String: Any]) {
         guard let id = dictionary["id"] as? String,
-              let deliveryID = dictionary["deliveryID"] as? Int,
+              let deliveryID = dictionary["deliveryID"] as? String,
               let carrierName = dictionary["carrierName"] as? String,
               let carrierIcon = dictionary["carrierIcon"] as? String,
               let latestStatus = dictionary["latestStatus"] as? String,


### PR DESCRIPTION
## Summary
- watchOS uses 32-bit Int (arm64_32), so 12-digit integer literals overflow
- Replace sample data literals with values that fit in 32-bit Int
- No logic changes, only preview/sample data values affected

## Changes
- `ComplicationController.swift`: 123456789012 → 1234567890, 987654321098 → 987654321
- `WatchDeliveryDetailView.swift`: 123456789012 → 1234567890