### PR TITLE
feat: Add end-to-end Sagawa tracking support

### DIFF
--- a/BlackCat/BlackCatApp.swift
+++ b/BlackCat/BlackCatApp.swift
@@ -133,7 +133,7 @@ extension BlackCatApp {
     /// DeliveryListViewModelの更新時に呼び出す
     static func syncWidgetData(deliveryItems: [DeliveryItem]) {
         let widgetItems = deliveryItems.compactMap { item -> WidgetDeliveryItem? in
-            guard let latestStatus = item.statusList.first else { return nil }
+            guard let latestStatus = item.statusList.last else { return nil }
             return WidgetDeliveryItem(
                 deliveryID: item.deliveryID,
                 latestStatus: latestStatus.status,

--- a/BlackCat/Models/DeliveryCarrier.swift
+++ b/BlackCat/Models/DeliveryCarrier.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import Domain
 
-enum DeliveryCarrier: String, CaseIterable, Identifiable {
+enum DeliveryCarrier: String, CaseIterable, Identifiable, Codable {
     case yamato = "ヤマト運輸"
     case sagawa = "佐川急便"
     case japanPost = "日本郵便"

--- a/BlackCat/Models/DeliveryItem.swift
+++ b/BlackCat/Models/DeliveryItem.swift
@@ -29,3 +29,14 @@ extension DeliveryItem {
         self.registeredDate = Date()
     }
 }
+
+extension DeliveryItem {
+    init(trackingInfo: Sagawa.TrackingInfo, carrier: DeliveryCarrier = .sagawa) {
+        self.deliveryID = Int(trackingInfo.trackingNumber) ?? 0
+        self.statusList = trackingInfo.statusList.map {
+            DeliveryStatus(sagawaStatus: $0)
+        }
+        self.carrier = carrier
+        self.registeredDate = Date()
+    }
+}

--- a/BlackCat/Models/DeliveryItem.swift
+++ b/BlackCat/Models/DeliveryItem.swift
@@ -10,7 +10,7 @@ struct DeliveryItem: Identifiable {
 
     /// 最新のステータスを取得
     var latestStatus: DeliveryStatus? {
-        statusList.first
+        statusList.last
     }
 
     /// 最新のステータスタイプを取得

--- a/BlackCat/Models/DeliveryStatus.swift
+++ b/BlackCat/Models/DeliveryStatus.swift
@@ -49,7 +49,7 @@ struct DeliveryStatus: Identifiable {
             return .delivered
         case "配達日・時間帯指定（保管中）":
             return .delivering
-        // 佐川急便のステータス
+        // Sagawa statuses
         case "集荷":
             return .received
         case "配送中":

--- a/BlackCat/Models/DeliveryStatus.swift
+++ b/BlackCat/Models/DeliveryStatus.swift
@@ -49,6 +49,21 @@ struct DeliveryStatus: Identifiable {
             return .delivered
         case "配達日・時間帯指定（保管中）":
             return .delivering
+        // 佐川急便のステータス
+        case "集荷":
+            return .received
+        case "配送中":
+            return .shipping
+        case "到着":
+            return .shipping
+        case "出荷":
+            return .sended
+        case "持戻り":
+            return .delivering
+        case "不在":
+            return .delivering
+        case "保管中":
+            return .delivering
         default:
             return nil
         }
@@ -61,5 +76,14 @@ extension DeliveryStatus {
         self.date = deliveryStatus.date
         self.time = deliveryStatus.time
         self.shopName = deliveryStatus.shopName
+    }
+}
+
+extension DeliveryStatus {
+    init(sagawaStatus: Sagawa.TrackingInfo.DeliveryStatus) {
+        self.status = sagawaStatus.status
+        self.date = sagawaStatus.date
+        self.time = sagawaStatus.time
+        self.shopName = sagawaStatus.location
     }
 }

--- a/BlackCat/Models/LocalDeliveryItems.swift
+++ b/BlackCat/Models/LocalDeliveryItems.swift
@@ -1,15 +1,36 @@
 import Foundation
 import WidgetKit
 
+// MARK: - StoredDeliveryItem
+
+/// キャリア情報を含む配達アイテムの永続化モデル
+struct StoredDeliveryItem: Codable, Equatable {
+    let trackingNumber: String
+    let carrier: DeliveryCarrier
+
+    /// 後方互換性のため、trackingNumber を Int に変換して返す（変換不可の場合は nil）
+    var trackingNumberInt: Int? {
+        return Int(trackingNumber)
+    }
+}
+
+// MARK: - LocalDeliveryItems
+
 final class LocalDeliveryItems {
     static let shared = LocalDeliveryItems()
     private let key = "ItemList"
+    private let storedItemsKey = "StoredItemList"
     /// App Group identifier for sharing data with widget
     private let appGroupIdentifier = "group.com.blackcat.delivery"
 
-    /// Items should be a read only property
-    /// if you want to add a content, use add method
-    private(set) var items: [Int]
+    /// Codable ベースの保存データ
+    private(set) var storedItems: [StoredDeliveryItem]
+
+    /// 後方互換性のための computed property
+    /// storedItems から trackingNumber の Int 値を返す
+    var items: [Int] {
+        return storedItems.compactMap { $0.trackingNumberInt }
+    }
 
     /// Standard UserDefaults (fallback)
     private let userdefaults = UserDefaults.standard
@@ -20,71 +41,142 @@ final class LocalDeliveryItems {
     }
 
     init() {
-        // Try to load from shared defaults first, then fallback to standard
         let sharedDefaultsInstance = UserDefaults(suiteName: appGroupIdentifier)
-        if let sharedDefaults = sharedDefaultsInstance,
-           let array = sharedDefaults.array(forKey: key) as? [Int] {
-            items = array
-        } else if let array = userdefaults.array(forKey: key) as? [Int] {
-            items = array
-            // Migrate to shared defaults
-            sharedDefaultsInstance?.set(array, forKey: key)
-        } else {
-            items = []
+
+        // 1. まず新形式 (StoredDeliveryItem) のデータを試みる
+        if let loaded = Self.loadStoredItems(from: sharedDefaultsInstance, key: "StoredItemList") {
+            storedItems = loaded
+        } else if let loaded = Self.loadStoredItems(from: UserDefaults.standard, key: "StoredItemList") {
+            storedItems = loaded
+            // shared defaults へ同期
+            Self.saveStoredItems(loaded, to: sharedDefaultsInstance, key: "StoredItemList")
         }
+        // 2. 新形式がなければ旧形式 ([Int]) からマイグレーション
+        else if let sharedDefaults = sharedDefaultsInstance,
+                let array = sharedDefaults.array(forKey: key) as? [Int] {
+            storedItems = Self.migrateFromIntArray(array)
+            Self.saveStoredItems(storedItems, to: sharedDefaultsInstance, key: "StoredItemList")
+            Self.saveStoredItems(storedItems, to: UserDefaults.standard, key: "StoredItemList")
+        } else if let array = UserDefaults.standard.array(forKey: key) as? [Int] {
+            storedItems = Self.migrateFromIntArray(array)
+            Self.saveStoredItems(storedItems, to: sharedDefaultsInstance, key: "StoredItemList")
+            Self.saveStoredItems(storedItems, to: UserDefaults.standard, key: "StoredItemList")
+        } else {
+            storedItems = []
+        }
+
+        // 旧形式のデータも引き続き同期しておく（Widget フォールバック用）
+        syncLegacyItems()
     }
 
-    func add(_ content: Int) {
-        items.insert(content, at: 0)
+    // MARK: - Public Methods
+
+    func add(_ content: Int, carrier: DeliveryCarrier = .yamato) {
+        let item = StoredDeliveryItem(trackingNumber: String(content), carrier: carrier)
+        storedItems.insert(item, at: 0)
         saveItems()
         NotificationCenter.default.post(name: .addItem, object: nil)
         reloadWidget()
     }
 
-    /// 文字列の追跡番号を追加（国際郵便など数字以外を含む番号にも対応）
-    /// 数値に変換可能な場合はIntとして保存し、不可能な場合はログ出力のみ
-    func addTrackingNumber(_ trackingNumber: String) {
-        if let intValue = Int(trackingNumber) {
-            add(intValue)
-        } else {
-            // 国際郵便番号（例: EA123456789JP）はInt変換不可
-            // TODO: LocalDeliveryItemsをString型に拡張して対応する
-            print("[LocalDeliveryItems] Warning: Cannot store non-numeric tracking number: \(trackingNumber)")
-            NotificationCenter.default.post(name: .addItem, object: nil)
-        }
+    /// 文字列の追跡番号を追加（キャリア情報付き）
+    func addTrackingNumber(_ trackingNumber: String, carrier: DeliveryCarrier = .yamato) {
+        let cleanedNumber = trackingNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: " ", with: "")
+
+        let item = StoredDeliveryItem(trackingNumber: cleanedNumber, carrier: carrier)
+        storedItems.insert(item, at: 0)
+        saveItems()
+        NotificationCenter.default.post(name: .addItem, object: nil)
+        reloadWidget()
     }
 
     func remove(id: Int) {
-        items.removeAll(where: { $0 == id })
+        storedItems.removeAll(where: { $0.trackingNumberInt == id })
         saveItems()
         NotificationCenter.default.post(name: .removeItem, object: nil)
         reloadWidget()
     }
 
     func update() {
-        if let sharedDefaults = sharedDefaults,
-           let array = sharedDefaults.array(forKey: key) as? [Int] {
-            items = array
+        let sharedDefaultsInstance = UserDefaults(suiteName: appGroupIdentifier)
+        if let loaded = Self.loadStoredItems(from: sharedDefaultsInstance, key: storedItemsKey) {
+            storedItems = loaded
+        } else if let loaded = Self.loadStoredItems(from: userdefaults, key: storedItemsKey) {
+            storedItems = loaded
+        } else if let sharedDefaults = sharedDefaultsInstance,
+                  let array = sharedDefaults.array(forKey: key) as? [Int] {
+            storedItems = Self.migrateFromIntArray(array)
         } else if let array = userdefaults.array(forKey: key) as? [Int] {
-            items = array
+            storedItems = Self.migrateFromIntArray(array)
         }
     }
 
     func removeDeplicates(deliveryItems newItems: [DeliveryItem]) {
-        items = newItems.compactMap {
-            $0.statusList.isEmpty ? nil : $0.deliveryID
+        let validIDs = Set(newItems.compactMap { item -> Int? in
+            item.statusList.isEmpty ? nil : item.deliveryID
+        })
+        storedItems = storedItems.filter { item in
+            guard let intValue = item.trackingNumberInt else { return true }
+            return validIDs.contains(intValue)
         }
         saveItems()
     }
 
+    /// 特定の追跡番号に対応する StoredDeliveryItem を取得
+    func storedItem(for trackingNumber: Int) -> StoredDeliveryItem? {
+        return storedItems.first(where: { $0.trackingNumberInt == trackingNumber })
+    }
+
+    /// 特定の追跡番号のキャリアを取得（見つからない場合は .yamato をデフォルトで返す）
+    func carrier(for trackingNumber: Int) -> DeliveryCarrier {
+        return storedItem(for: trackingNumber)?.carrier ?? .yamato
+    }
+
+    // MARK: - Private Methods
+
     /// Save items to both standard and shared UserDefaults
     private func saveItems() {
-        userdefaults.set(items, forKey: key)
-        sharedDefaults?.set(items, forKey: key)
+        // 新形式で保存
+        Self.saveStoredItems(storedItems, to: userdefaults, key: storedItemsKey)
+        Self.saveStoredItems(storedItems, to: sharedDefaults, key: storedItemsKey)
+
+        // 旧形式も同期（Widget フォールバック用）
+        syncLegacyItems()
+    }
+
+    /// 旧形式の [Int] データを同期（後方互換性・Widget用）
+    private func syncLegacyItems() {
+        let legacyItems = items
+        userdefaults.set(legacyItems, forKey: key)
+        sharedDefaults?.set(legacyItems, forKey: key)
     }
 
     /// Reload widget timeline
     private func reloadWidget() {
         WidgetCenter.shared.reloadTimelines(ofKind: "BlackCarWidget")
+    }
+
+    // MARK: - Static Helpers
+
+    /// 旧形式の [Int] 配列を StoredDeliveryItem 配列にマイグレーション
+    /// 既存データは全て .yamato として扱う
+    private static func migrateFromIntArray(_ array: [Int]) -> [StoredDeliveryItem] {
+        return array.map { StoredDeliveryItem(trackingNumber: String($0), carrier: .yamato) }
+    }
+
+    /// UserDefaults から StoredDeliveryItem 配列を読み込む
+    private static func loadStoredItems(from defaults: UserDefaults?, key: String) -> [StoredDeliveryItem]? {
+        guard let defaults = defaults,
+              let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode([StoredDeliveryItem].self, from: data)
+    }
+
+    /// UserDefaults に StoredDeliveryItem 配列を保存する
+    private static func saveStoredItems(_ items: [StoredDeliveryItem], to defaults: UserDefaults?, key: String) {
+        guard let defaults = defaults,
+              let data = try? JSONEncoder().encode(items) else { return }
+        defaults.set(data, forKey: key)
     }
 }

--- a/BlackCat/Models/LocalDeliveryItems.swift
+++ b/BlackCat/Models/LocalDeliveryItems.swift
@@ -3,12 +3,12 @@ import WidgetKit
 
 // MARK: - StoredDeliveryItem
 
-/// キャリア情報を含む配達アイテムの永続化モデル
+/// Persistent model for delivery items with carrier information
 struct StoredDeliveryItem: Codable, Equatable {
     let trackingNumber: String
     let carrier: DeliveryCarrier
 
-    /// 後方互換性のため、trackingNumber を Int に変換して返す（変換不可の場合は nil）
+    /// Converts trackingNumber to Int for backward compatibility (nil if not convertible)
     var trackingNumberInt: Int? {
         return Int(trackingNumber)
     }
@@ -23,11 +23,11 @@ final class LocalDeliveryItems {
     /// App Group identifier for sharing data with widget
     private let appGroupIdentifier = "group.com.blackcat.delivery"
 
-    /// Codable ベースの保存データ
+    /// Codable-based stored data
     private(set) var storedItems: [StoredDeliveryItem]
 
-    /// 後方互換性のための computed property
-    /// storedItems から trackingNumber の Int 値を返す
+    /// Computed property for backward compatibility
+    /// Returns Int values of trackingNumber from storedItems
     var items: [Int] {
         return storedItems.compactMap { $0.trackingNumberInt }
     }
@@ -43,15 +43,15 @@ final class LocalDeliveryItems {
     init() {
         let sharedDefaultsInstance = UserDefaults(suiteName: appGroupIdentifier)
 
-        // 1. まず新形式 (StoredDeliveryItem) のデータを試みる
+        // 1. Try loading new format (StoredDeliveryItem) first
         if let loaded = Self.loadStoredItems(from: sharedDefaultsInstance, key: "StoredItemList") {
             storedItems = loaded
         } else if let loaded = Self.loadStoredItems(from: UserDefaults.standard, key: "StoredItemList") {
             storedItems = loaded
-            // shared defaults へ同期
+            // Sync to shared defaults
             Self.saveStoredItems(loaded, to: sharedDefaultsInstance, key: "StoredItemList")
         }
-        // 2. 新形式がなければ旧形式 ([Int]) からマイグレーション
+        // 2. Fall back to legacy format ([Int]) and migrate
         else if let sharedDefaults = sharedDefaultsInstance,
                 let array = sharedDefaults.array(forKey: key) as? [Int] {
             storedItems = Self.migrateFromIntArray(array)
@@ -65,7 +65,7 @@ final class LocalDeliveryItems {
             storedItems = []
         }
 
-        // 旧形式のデータも引き続き同期しておく（Widget フォールバック用）
+        // Keep legacy format in sync for Widget fallback
         syncLegacyItems()
     }
 
@@ -79,7 +79,7 @@ final class LocalDeliveryItems {
         reloadWidget()
     }
 
-    /// 文字列の追跡番号を追加（キャリア情報付き）
+    /// Add tracking number as string with carrier info
     func addTrackingNumber(_ trackingNumber: String, carrier: DeliveryCarrier = .yamato) {
         let cleanedNumber = trackingNumber.trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "-", with: "")
@@ -124,12 +124,12 @@ final class LocalDeliveryItems {
         saveItems()
     }
 
-    /// 特定の追跡番号に対応する StoredDeliveryItem を取得
+    /// Get StoredDeliveryItem for a specific tracking number
     func storedItem(for trackingNumber: Int) -> StoredDeliveryItem? {
         return storedItems.first(where: { $0.trackingNumberInt == trackingNumber })
     }
 
-    /// 特定の追跡番号のキャリアを取得（見つからない場合は .yamato をデフォルトで返す）
+    /// Get carrier for a specific tracking number (defaults to .yamato if not found)
     func carrier(for trackingNumber: Int) -> DeliveryCarrier {
         return storedItem(for: trackingNumber)?.carrier ?? .yamato
     }
@@ -138,15 +138,15 @@ final class LocalDeliveryItems {
 
     /// Save items to both standard and shared UserDefaults
     private func saveItems() {
-        // 新形式で保存
+        // Save in new format
         Self.saveStoredItems(storedItems, to: userdefaults, key: storedItemsKey)
         Self.saveStoredItems(storedItems, to: sharedDefaults, key: storedItemsKey)
 
-        // 旧形式も同期（Widget フォールバック用）
+        // Sync legacy format for Widget fallback
         syncLegacyItems()
     }
 
-    /// 旧形式の [Int] データを同期（後方互換性・Widget用）
+    /// Sync legacy [Int] data for backward compatibility and Widget
     private func syncLegacyItems() {
         let legacyItems = items
         userdefaults.set(legacyItems, forKey: key)
@@ -160,20 +160,20 @@ final class LocalDeliveryItems {
 
     // MARK: - Static Helpers
 
-    /// 旧形式の [Int] 配列を StoredDeliveryItem 配列にマイグレーション
-    /// 既存データは全て .yamato として扱う
+    /// Migrate legacy [Int] array to StoredDeliveryItem array
+    /// All existing data is treated as .yamato
     private static func migrateFromIntArray(_ array: [Int]) -> [StoredDeliveryItem] {
         return array.map { StoredDeliveryItem(trackingNumber: String($0), carrier: .yamato) }
     }
 
-    /// UserDefaults から StoredDeliveryItem 配列を読み込む
+    /// Load StoredDeliveryItem array from UserDefaults
     private static func loadStoredItems(from defaults: UserDefaults?, key: String) -> [StoredDeliveryItem]? {
         guard let defaults = defaults,
               let data = defaults.data(forKey: key) else { return nil }
         return try? JSONDecoder().decode([StoredDeliveryItem].self, from: data)
     }
 
-    /// UserDefaults に StoredDeliveryItem 配列を保存する
+    /// Save StoredDeliveryItem array to UserDefaults
     private static func saveStoredItems(_ items: [StoredDeliveryItem], to defaults: UserDefaults?, key: String) {
         guard let defaults = defaults,
               let data = try? JSONEncoder().encode(items) else { return }

--- a/BlackCat/Scenes/AddList/AddListViewModel.swift
+++ b/BlackCat/Scenes/AddList/AddListViewModel.swift
@@ -110,7 +110,8 @@ final class AddListViewModel: ObservableObject, AddListViewModelType, AddListVie
                 .catch { _ in Just(nil) }
                 .eraseToAnyPublisher()
             }
-            .sink(receiveValue: { deliveryInfo in
+            .sink(receiveValue: { [weak self] deliveryInfo in
+                guard let self = self else { return }
                 self.isLoading = false
                 guard let deliveryInfo = deliveryInfo else {
                     self.errorMessage = "登録に失敗しました"
@@ -121,7 +122,10 @@ final class AddListViewModel: ObservableObject, AddListViewModelType, AddListVie
                 self.errorMessage = hasStatus ? "登録に成功しました" : "登録に失敗しました"
                 self.showingAlert = true
                 if hasStatus {
-                    LocalDeliveryItems.shared.addTrackingNumber(deliveryInfo.trackingNumber)
+                    LocalDeliveryItems.shared.addTrackingNumber(
+                        deliveryInfo.trackingNumber,
+                        carrier: self.carrierPublisher
+                    )
                     self.isSuccessfullyAdded = true
                 }
             })

--- a/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
+++ b/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
@@ -5,17 +5,6 @@ import WidgetKit
 import UserNotifications
 import WatchConnectivity
 
-// MARK: - Debug Logging Helper
-#if DEBUG
-@inline(__always)
-private func sagawaDebugLog(_ message: @autoclosure () -> String) {
-    print("[SAGAWA_DEBUG] \(message())")
-}
-#else
-@inline(__always)
-private func sagawaDebugLog(_ message: @autoclosure () -> String) {}
-#endif
-
 // MARK: - Filter & Sort Types
 
 /// ステータスフィルター用の列挙型
@@ -358,30 +347,17 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
 
     /// Fetch Sagawa delivery info in parallel (one API call per item via TaskGroup)
     private func fetchSagawaItems(trackingNumbers: [String]) async -> [DeliveryItem] {
-        sagawaDebugLog("fetchSagawaItems() - START - trackingNumbers: \(trackingNumbers)")
-        guard !trackingNumbers.isEmpty else {
-            sagawaDebugLog("fetchSagawaItems() - trackingNumbers is empty, returning []")
-            return []
-        }
+        guard !trackingNumbers.isEmpty else { return [] }
 
         return await withTaskGroup(of: DeliveryItem?.self, returning: [DeliveryItem].self) { group in
             for trackingNumber in trackingNumbers {
                 group.addTask { [apiClient] in
-                    sagawaDebugLog("fetchSagawaItems() - calling API for trackingNumber: \(trackingNumber)")
                     let result = await apiClient.sagawa(SagawaRequest(trackingNumber: trackingNumber))
-                    if let sagawa = result.value {
-                        sagawaDebugLog("fetchSagawaItems() - API success for \(trackingNumber) - trackingList count: \(sagawa.trackingList.count), first statusList count: \(sagawa.trackingList.first?.statusList.count ?? 0)")
-                        guard let trackingInfo = sagawa.trackingList.first else {
-                            sagawaDebugLog("fetchSagawaItems() - trackingList is empty for \(trackingNumber)")
-                            return nil
-                        }
-                        let deliveryItem = DeliveryItem(trackingInfo: trackingInfo)
-                        sagawaDebugLog("fetchSagawaItems() - DeliveryItem created - deliveryID: \(deliveryItem.deliveryID), statusList count: \(deliveryItem.statusList.count)")
-                        return deliveryItem
-                    } else {
-                        sagawaDebugLog("fetchSagawaItems() - API failure for \(trackingNumber) - error: \(result.error?.localizedDescription ?? "unknown")")
+                    guard let sagawa = result.value,
+                          let trackingInfo = sagawa.trackingList.first else {
                         return nil
                     }
+                    return DeliveryItem(trackingInfo: trackingInfo)
                 }
             }
 
@@ -391,7 +367,6 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
                     items.append(item)
                 }
             }
-            sagawaDebugLog("fetchSagawaItems() - COMPLETE - total items: \(items.count)")
             return items
         }
     }
@@ -429,7 +404,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
     /// - Parameter newItems: 新しい配達アイテムリスト
     private func checkAndNotifyStatusChanges(newItems: [DeliveryItem]) {
         for item in newItems {
-            guard let latestStatus = item.statusList.first else { continue }
+            guard let latestStatus = item.statusList.last else { continue }
 
             let deliveryID = item.deliveryID
             let currentStatus = latestStatus.status

--- a/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
+++ b/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
@@ -5,6 +5,17 @@ import WidgetKit
 import UserNotifications
 import WatchConnectivity
 
+// MARK: - Debug Logging Helper
+#if DEBUG
+@inline(__always)
+private func sagawaDebugLog(_ message: @autoclosure () -> String) {
+    print("[SAGAWA_DEBUG] \(message())")
+}
+#else
+@inline(__always)
+private func sagawaDebugLog(_ message: @autoclosure () -> String) {}
+#endif
+
 // MARK: - Filter & Sort Types
 
 /// ステータスフィルター用の列挙型
@@ -284,7 +295,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
     }
 
     /// データ読み込みの非同期実装（完了を待機可能）
-    /// ヤマト・佐川のマルチキャリアに対応
+    /// Multi-carrier support for Yamato and Sagawa
     @MainActor
     private func loadItemAsync() async {
         let allStoredItems = LocalDeliveryItems.shared.storedItems
@@ -295,7 +306,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
 
         isLoading = true
 
-        // キャリアごとにグルーピング
+        // Group by carrier
         let yamatoNumbers = allStoredItems
             .filter { $0.carrier == .yamato }
             .compactMap { $0.trackingNumberInt }
@@ -306,7 +317,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
 
         var allDeliveryItems: [DeliveryItem] = []
 
-        // ヤマトと佐川を並行で取得
+        // Fetch Yamato and Sagawa in parallel
         async let yamatoItems = fetchYamatoItems(numbers: yamatoNumbers)
         async let sagawaItems = fetchSagawaItems(trackingNumbers: sagawaNumbers)
 
@@ -337,7 +348,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
 
     // MARK: - Carrier-specific Fetch Methods
 
-    /// ヤマト運輸の配送情報を一括取得
+    /// Fetch Yamato delivery info in batch
     private func fetchYamatoItems(numbers: [Int]) async -> [DeliveryItem] {
         guard !numbers.isEmpty else { return [] }
         let result = await apiClient.tneko(.init(numbers: numbers))
@@ -345,17 +356,32 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
         return TnekoClient(tneko: tneko).deliveryList
     }
 
-    /// 佐川急便の配送情報を並行取得（1件ずつAPIを呼び出し、TaskGroupで並行実行）
+    /// Fetch Sagawa delivery info in parallel (one API call per item via TaskGroup)
     private func fetchSagawaItems(trackingNumbers: [String]) async -> [DeliveryItem] {
-        guard !trackingNumbers.isEmpty else { return [] }
+        sagawaDebugLog("fetchSagawaItems() - START - trackingNumbers: \(trackingNumbers)")
+        guard !trackingNumbers.isEmpty else {
+            sagawaDebugLog("fetchSagawaItems() - trackingNumbers is empty, returning []")
+            return []
+        }
 
         return await withTaskGroup(of: DeliveryItem?.self, returning: [DeliveryItem].self) { group in
             for trackingNumber in trackingNumbers {
                 group.addTask { [apiClient] in
+                    sagawaDebugLog("fetchSagawaItems() - calling API for trackingNumber: \(trackingNumber)")
                     let result = await apiClient.sagawa(SagawaRequest(trackingNumber: trackingNumber))
-                    guard let sagawa = result.value else { return nil }
-                    guard let trackingInfo = sagawa.trackingList.first else { return nil }
-                    return DeliveryItem(trackingInfo: trackingInfo)
+                    if let sagawa = result.value {
+                        sagawaDebugLog("fetchSagawaItems() - API success for \(trackingNumber) - trackingList count: \(sagawa.trackingList.count), first statusList count: \(sagawa.trackingList.first?.statusList.count ?? 0)")
+                        guard let trackingInfo = sagawa.trackingList.first else {
+                            sagawaDebugLog("fetchSagawaItems() - trackingList is empty for \(trackingNumber)")
+                            return nil
+                        }
+                        let deliveryItem = DeliveryItem(trackingInfo: trackingInfo)
+                        sagawaDebugLog("fetchSagawaItems() - DeliveryItem created - deliveryID: \(deliveryItem.deliveryID), statusList count: \(deliveryItem.statusList.count)")
+                        return deliveryItem
+                    } else {
+                        sagawaDebugLog("fetchSagawaItems() - API failure for \(trackingNumber) - error: \(result.error?.localizedDescription ?? "unknown")")
+                        return nil
+                    }
                 }
             }
 
@@ -365,6 +391,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
                     items.append(item)
                 }
             }
+            sagawaDebugLog("fetchSagawaItems() - COMPLETE - total items: \(items.count)")
             return items
         }
     }

--- a/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
+++ b/BlackCat/Scenes/DeliveryList/DeliveryListViewModel.swift
@@ -273,7 +273,7 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
     }
 
     private func loadItem() {
-        guard !goodsIdList.isEmpty else {
+        guard !LocalDeliveryItems.shared.storedItems.isEmpty else {
             deliveryList = []
             return
         }
@@ -284,33 +284,89 @@ final class DeliveryListViewModel: ObservableObject, DeliveryListViewModelType, 
     }
 
     /// データ読み込みの非同期実装（完了を待機可能）
+    /// ヤマト・佐川のマルチキャリアに対応
     @MainActor
     private func loadItemAsync() async {
-        guard !goodsIdList.isEmpty else {
+        let allStoredItems = LocalDeliveryItems.shared.storedItems
+        guard !allStoredItems.isEmpty else {
             deliveryList = []
             return
         }
 
         isLoading = true
-        let result = await apiClient.tneko(.init(numbers: goodsIdList))
+
+        // キャリアごとにグルーピング
+        let yamatoNumbers = allStoredItems
+            .filter { $0.carrier == .yamato }
+            .compactMap { $0.trackingNumberInt }
+        let sagawaNumbers = allStoredItems
+            .filter { $0.carrier == .sagawa }
+            .compactMap { $0.trackingNumber as String? }
+            .filter { !$0.isEmpty }
+
+        var allDeliveryItems: [DeliveryItem] = []
+
+        // ヤマトと佐川を並行で取得
+        async let yamatoItems = fetchYamatoItems(numbers: yamatoNumbers)
+        async let sagawaItems = fetchSagawaItems(trackingNumbers: sagawaNumbers)
+
+        let yamatoResult = await yamatoItems
+        let sagawaResult = await sagawaItems
+
+        allDeliveryItems.append(contentsOf: yamatoResult)
+        allDeliveryItems.append(contentsOf: sagawaResult)
+
         isLoading = false
-        guard let tneko = result.value else { return }
-        let tnekoClient = TnekoClient(tneko: tneko)
+
         if isInitialLoad {
-            LocalDeliveryItems.shared.removeDeplicates(deliveryItems: tnekoClient.deliveryList)
+            LocalDeliveryItems.shared.removeDeplicates(deliveryItems: allDeliveryItems)
             isInitialLoad = false
         }
 
         // 配達状況の変更を検知して通知を送信
-        checkAndNotifyStatusChanges(newItems: tnekoClient.deliveryList)
+        checkAndNotifyStatusChanges(newItems: allDeliveryItems)
 
-        self.deliveryList = tnekoClient.deliveryList
+        self.deliveryList = allDeliveryItems
 
         // ウィジェットにデータを同期
-        BlackCatApp.syncWidgetData(deliveryItems: tnekoClient.deliveryList)
+        BlackCatApp.syncWidgetData(deliveryItems: allDeliveryItems)
 
         // Apple Watchにデータを同期
-        BlackCatApp.syncWatchData(deliveryItems: tnekoClient.deliveryList)
+        BlackCatApp.syncWatchData(deliveryItems: allDeliveryItems)
+    }
+
+    // MARK: - Carrier-specific Fetch Methods
+
+    /// ヤマト運輸の配送情報を一括取得
+    private func fetchYamatoItems(numbers: [Int]) async -> [DeliveryItem] {
+        guard !numbers.isEmpty else { return [] }
+        let result = await apiClient.tneko(.init(numbers: numbers))
+        guard let tneko = result.value else { return [] }
+        return TnekoClient(tneko: tneko).deliveryList
+    }
+
+    /// 佐川急便の配送情報を並行取得（1件ずつAPIを呼び出し、TaskGroupで並行実行）
+    private func fetchSagawaItems(trackingNumbers: [String]) async -> [DeliveryItem] {
+        guard !trackingNumbers.isEmpty else { return [] }
+
+        return await withTaskGroup(of: DeliveryItem?.self, returning: [DeliveryItem].self) { group in
+            for trackingNumber in trackingNumbers {
+                group.addTask { [apiClient] in
+                    let result = await apiClient.sagawa(SagawaRequest(trackingNumber: trackingNumber))
+                    guard let sagawa = result.value else { return nil }
+                    guard let trackingInfo = sagawa.trackingList.first else { return nil }
+                    return DeliveryItem(trackingInfo: trackingInfo)
+                }
+            }
+
+            var items: [DeliveryItem] = []
+            for await item in group {
+                if let item = item {
+                    items.append(item)
+                }
+            }
+            return items
+        }
     }
 
     // MARK: - Watch Connectivity Setup

--- a/BlackCat/Utils/BackgroundRefreshManager.swift
+++ b/BlackCat/Utils/BackgroundRefreshManager.swift
@@ -351,7 +351,7 @@ final class BackgroundRefreshManager: ObservableObject {
     /// 配達状況の変更を検知して通知を送信
     private func checkAndNotifyStatusChanges(items: [DeliveryItem]) async {
         for item in items {
-            guard let latestStatus = item.statusList.first else { continue }
+            guard let latestStatus = item.statusList.last else { continue }
 
             let deliveryID = item.deliveryID
             let currentStatus = latestStatus.status

--- a/BlackCat/Utils/BackgroundRefreshManager.swift
+++ b/BlackCat/Utils/BackgroundRefreshManager.swift
@@ -263,36 +263,89 @@ final class BackgroundRefreshManager: ObservableObject {
         }
     }
 
-    /// 配達状況を更新
+    /// 配達状況を更新（ヤマト・佐川マルチキャリア対応）
     @discardableResult
     private func refreshDeliveryStatus() async -> Bool {
-        let deliveryIDs = LocalDeliveryItems.shared.items
+        let allStoredItems = LocalDeliveryItems.shared.storedItems
 
-        guard !deliveryIDs.isEmpty else {
+        guard !allStoredItems.isEmpty else {
             print("[BackgroundRefreshManager] No delivery items to refresh")
             return true
         }
 
-        print("[BackgroundRefreshManager] Refreshing \(deliveryIDs.count) delivery items")
+        print("[BackgroundRefreshManager] Refreshing \(allStoredItems.count) delivery items")
 
-        // APIから最新の配達状況を取得
-        let result = await apiClient.tneko(.init(numbers: deliveryIDs))
+        // キャリアごとにグルーピング
+        let yamatoNumbers = allStoredItems
+            .filter { $0.carrier == .yamato }
+            .compactMap { $0.trackingNumberInt }
+        let sagawaNumbers = allStoredItems
+            .filter { $0.carrier == .sagawa }
+            .compactMap { $0.trackingNumber as String? }
+            .filter { !$0.isEmpty }
 
-        guard let tneko = result.value else {
-            print("[BackgroundRefreshManager] Failed to fetch delivery status")
+        // ヤマトと佐川を並行で取得
+        async let yamatoItems = fetchYamatoItems(numbers: yamatoNumbers)
+        async let sagawaItems = fetchSagawaItems(trackingNumbers: sagawaNumbers)
+
+        let yamatoResult = await yamatoItems
+        let sagawaResult = await sagawaItems
+
+        var allDeliveryItems: [DeliveryItem] = []
+        allDeliveryItems.append(contentsOf: yamatoResult)
+        allDeliveryItems.append(contentsOf: sagawaResult)
+
+        // 1件も取得できなかった場合は失敗とみなす（ただし全キャリアが空の場合は成功）
+        if allDeliveryItems.isEmpty && (!yamatoNumbers.isEmpty || !sagawaNumbers.isEmpty) {
+            print("[BackgroundRefreshManager] Failed to fetch any delivery status")
             return false
         }
 
-        let deliveryItems = tneko.deliveryList.map { DeliveryItem(deliveryList: $0) }
-
         // 状態変更を検知して通知を送信
-        await checkAndNotifyStatusChanges(items: deliveryItems)
+        await checkAndNotifyStatusChanges(items: allDeliveryItems)
 
         // ウィジェットデータを同期
-        BlackCatApp.syncWidgetData(deliveryItems: deliveryItems)
+        BlackCatApp.syncWidgetData(deliveryItems: allDeliveryItems)
 
         print("[BackgroundRefreshManager] Delivery status refresh completed")
         return true
+    }
+
+    // MARK: - Carrier-specific Fetch Methods
+
+    /// ヤマト運輸の配送情報を一括取得
+    private func fetchYamatoItems(numbers: [Int]) async -> [DeliveryItem] {
+        guard !numbers.isEmpty else { return [] }
+        let result = await apiClient.tneko(.init(numbers: numbers))
+        guard let tneko = result.value else {
+            print("[BackgroundRefreshManager] Failed to fetch Yamato delivery status")
+            return []
+        }
+        return tneko.deliveryList.map { DeliveryItem(deliveryList: $0) }
+    }
+
+    /// 佐川急便の配送情報を並行取得（1件ずつAPIを呼び出し、TaskGroupで並行実行）
+    private func fetchSagawaItems(trackingNumbers: [String]) async -> [DeliveryItem] {
+        guard !trackingNumbers.isEmpty else { return [] }
+
+        return await withTaskGroup(of: DeliveryItem?.self, returning: [DeliveryItem].self) { group in
+            for trackingNumber in trackingNumbers {
+                group.addTask { [apiClient] in
+                    let result = await apiClient.sagawa(SagawaRequest(trackingNumber: trackingNumber))
+                    guard let sagawa = result.value else { return nil }
+                    guard let trackingInfo = sagawa.trackingList.first else { return nil }
+                    return DeliveryItem(trackingInfo: trackingInfo)
+                }
+            }
+
+            var items: [DeliveryItem] = []
+            for await item in group {
+                if let item = item {
+                    items.append(item)
+                }
+            }
+            return items
+        }
     }
 
     /// 配達状況の変更を検知して通知を送信

--- a/Domain/APIProtcols/APIClient+Endpoints.swift
+++ b/Domain/APIProtcols/APIClient+Endpoints.swift
@@ -71,9 +71,11 @@ public extension ApiClient {
     ///   - useCache: キャッシュを使用するかどうか（デフォルト: true）
     ///   - completion: 結果のコールバック
     func sagawa(_ request: SagawaRequest, useCache: Bool = true, completion: @escaping (Result<Sagawa, APIError>) -> Void) {
+        sagawaDebugLog("sagawa() called - trackingNumber: \(request.trackingNumber), useCache: \(useCache)")
         // キャッシュチェック
         if useCache && configuration.cacheEnabled {
             if let cached = cache.get(for: request.trackingNumber, carrier: .sagawa) {
+                sagawaDebugLog("sagawa() cache hit - returning cached result")
                 let sagawa = sagawaFromCache([cached])
                 completion(.success(sagawa))
                 return
@@ -81,6 +83,7 @@ public extension ApiClient {
         }
 
         guard let urlRequest: URLRequest = URLRequest(request, baseURL: sagawaBaseURL) else {
+            sagawaDebugLog("sagawa() URLRequest generation failed - invalidURL")
             completion(.failure(.invalidURL))
             return
         }
@@ -93,12 +96,15 @@ public extension ApiClient {
 
             switch result {
             case .success(let data):
+                sagawaDebugLog("sagawa() fetchWithRetry success - data size: \(data.count) bytes")
                 switch self.parseHTML(from: data) {
                 case .success(let htmlString):
+                    sagawaDebugLog("sagawa() parseHTML success - preview: \(String(htmlString.prefix(200)))")
                     let sagawa = Sagawa(
                         trackingNumber: request.trackingNumber,
                         response: htmlString
                     )
+                    sagawaDebugLog("sagawa() Sagawa object created - trackingList count: \(sagawa.trackingList.count), statusList counts: \(sagawa.trackingList.map { $0.statusList.count })")
 
                     // キャッシュに保存
                     if self.configuration.cacheEnabled {
@@ -108,10 +114,12 @@ public extension ApiClient {
                     completion(.success(sagawa))
 
                 case .failure(let error):
+                    sagawaDebugLog("sagawa() parseHTML failed - error: \(error)")
                     self.handleErrorWithCache(error: error, request: request, completion: completion)
                 }
 
             case .failure(let error):
+                sagawaDebugLog("sagawa() fetchWithRetry failed - error: \(error)")
                 self.handleErrorWithCache(error: error, request: request, completion: completion)
             }
         }
@@ -233,15 +241,18 @@ public extension ApiClient {
     ///   - useCache: キャッシュを使用するかどうか（デフォルト: true）
     /// - Returns: Result<Sagawa, APIError>
     func sagawa(_ request: SagawaRequest, useCache: Bool = true) async -> Result<Sagawa, APIError> {
+        sagawaDebugLog("sagawa() async called - trackingNumber: \(request.trackingNumber), useCache: \(useCache)")
         // キャッシュチェック
         if useCache && configuration.cacheEnabled {
             if let cached = cache.get(for: request.trackingNumber, carrier: .sagawa) {
+                sagawaDebugLog("sagawa() async cache hit - returning cached result")
                 let sagawa = sagawaFromCache([cached])
                 return .success(sagawa)
             }
         }
 
         guard let urlRequest: URLRequest = URLRequest(request, baseURL: sagawaBaseURL) else {
+            sagawaDebugLog("sagawa() async URLRequest generation failed - invalidURL")
             return .failure(.invalidURL)
         }
 
@@ -249,12 +260,15 @@ public extension ApiClient {
 
         switch result {
         case .success(let data):
+            sagawaDebugLog("sagawa() async fetchWithRetry success - data size: \(data.count) bytes")
             switch parseHTML(from: data) {
             case .success(let htmlString):
+                sagawaDebugLog("sagawa() async parseHTML success - preview: \(String(htmlString.prefix(200)))")
                 let sagawa = Sagawa(
                     trackingNumber: request.trackingNumber,
                     response: htmlString
                 )
+                sagawaDebugLog("sagawa() async Sagawa object created - trackingList count: \(sagawa.trackingList.count), statusList counts: \(sagawa.trackingList.map { $0.statusList.count })")
 
                 // キャッシュに保存
                 if configuration.cacheEnabled {
@@ -264,10 +278,12 @@ public extension ApiClient {
                 return .success(sagawa)
 
             case .failure(let error):
+                sagawaDebugLog("sagawa() async parseHTML failed - error: \(error)")
                 return handleErrorWithCacheAsync(error: error, request: request)
             }
 
         case .failure(let error):
+            sagawaDebugLog("sagawa() async fetchWithRetry failed - error: \(error)")
             return handleErrorWithCacheAsync(error: error, request: request)
         }
     }

--- a/Domain/APIProtcols/APIClient+Endpoints.swift
+++ b/Domain/APIProtcols/APIClient+Endpoints.swift
@@ -71,11 +71,9 @@ public extension ApiClient {
     ///   - useCache: キャッシュを使用するかどうか（デフォルト: true）
     ///   - completion: 結果のコールバック
     func sagawa(_ request: SagawaRequest, useCache: Bool = true, completion: @escaping (Result<Sagawa, APIError>) -> Void) {
-        sagawaDebugLog("sagawa() called - trackingNumber: \(request.trackingNumber), useCache: \(useCache)")
         // キャッシュチェック
         if useCache && configuration.cacheEnabled {
             if let cached = cache.get(for: request.trackingNumber, carrier: .sagawa) {
-                sagawaDebugLog("sagawa() cache hit - returning cached result")
                 let sagawa = sagawaFromCache([cached])
                 completion(.success(sagawa))
                 return
@@ -83,7 +81,6 @@ public extension ApiClient {
         }
 
         guard let urlRequest: URLRequest = URLRequest(request, baseURL: sagawaBaseURL) else {
-            sagawaDebugLog("sagawa() URLRequest generation failed - invalidURL")
             completion(.failure(.invalidURL))
             return
         }
@@ -96,15 +93,12 @@ public extension ApiClient {
 
             switch result {
             case .success(let data):
-                sagawaDebugLog("sagawa() fetchWithRetry success - data size: \(data.count) bytes")
                 switch self.parseHTML(from: data) {
                 case .success(let htmlString):
-                    sagawaDebugLog("sagawa() parseHTML success - preview: \(String(htmlString.prefix(200)))")
                     let sagawa = Sagawa(
                         trackingNumber: request.trackingNumber,
                         response: htmlString
                     )
-                    sagawaDebugLog("sagawa() Sagawa object created - trackingList count: \(sagawa.trackingList.count), statusList counts: \(sagawa.trackingList.map { $0.statusList.count })")
 
                     // キャッシュに保存
                     if self.configuration.cacheEnabled {
@@ -114,12 +108,10 @@ public extension ApiClient {
                     completion(.success(sagawa))
 
                 case .failure(let error):
-                    sagawaDebugLog("sagawa() parseHTML failed - error: \(error)")
                     self.handleErrorWithCache(error: error, request: request, completion: completion)
                 }
 
             case .failure(let error):
-                sagawaDebugLog("sagawa() fetchWithRetry failed - error: \(error)")
                 self.handleErrorWithCache(error: error, request: request, completion: completion)
             }
         }
@@ -241,18 +233,15 @@ public extension ApiClient {
     ///   - useCache: キャッシュを使用するかどうか（デフォルト: true）
     /// - Returns: Result<Sagawa, APIError>
     func sagawa(_ request: SagawaRequest, useCache: Bool = true) async -> Result<Sagawa, APIError> {
-        sagawaDebugLog("sagawa() async called - trackingNumber: \(request.trackingNumber), useCache: \(useCache)")
         // キャッシュチェック
         if useCache && configuration.cacheEnabled {
             if let cached = cache.get(for: request.trackingNumber, carrier: .sagawa) {
-                sagawaDebugLog("sagawa() async cache hit - returning cached result")
                 let sagawa = sagawaFromCache([cached])
                 return .success(sagawa)
             }
         }
 
         guard let urlRequest: URLRequest = URLRequest(request, baseURL: sagawaBaseURL) else {
-            sagawaDebugLog("sagawa() async URLRequest generation failed - invalidURL")
             return .failure(.invalidURL)
         }
 
@@ -260,15 +249,12 @@ public extension ApiClient {
 
         switch result {
         case .success(let data):
-            sagawaDebugLog("sagawa() async fetchWithRetry success - data size: \(data.count) bytes")
             switch parseHTML(from: data) {
             case .success(let htmlString):
-                sagawaDebugLog("sagawa() async parseHTML success - preview: \(String(htmlString.prefix(200)))")
                 let sagawa = Sagawa(
                     trackingNumber: request.trackingNumber,
                     response: htmlString
                 )
-                sagawaDebugLog("sagawa() async Sagawa object created - trackingList count: \(sagawa.trackingList.count), statusList counts: \(sagawa.trackingList.map { $0.statusList.count })")
 
                 // キャッシュに保存
                 if configuration.cacheEnabled {
@@ -278,12 +264,10 @@ public extension ApiClient {
                 return .success(sagawa)
 
             case .failure(let error):
-                sagawaDebugLog("sagawa() async parseHTML failed - error: \(error)")
                 return handleErrorWithCacheAsync(error: error, request: request)
             }
 
         case .failure(let error):
-            sagawaDebugLog("sagawa() async fetchWithRetry failed - error: \(error)")
             return handleErrorWithCacheAsync(error: error, request: request)
         }
     }

--- a/Domain/APIProtcols/ApiClient.swift
+++ b/Domain/APIProtcols/ApiClient.swift
@@ -195,7 +195,9 @@ extension ApiClient {
 extension ApiClient {
     /// HTMLデータをパースしてAttributedStringに変換
     internal func parseHTML(from data: Data) -> Result<String, APIError> {
+        sagawaDebugLog("parseHTML() called - data size: \(data.count) bytes")
         guard !data.isEmpty else {
+            sagawaDebugLog("parseHTML() empty data received")
             return .failure(.emptyData)
         }
 
@@ -204,9 +206,12 @@ extension ApiClient {
             options: [.documentType: NSAttributedString.DocumentType.html],
             documentAttributes: nil
         ) else {
+            sagawaDebugLog("parseHTML() NSAttributedString conversion failed")
             return .failure(.htmlParseError("Failed to parse HTML content"))
         }
 
+        sagawaDebugLog("parseHTML() NSAttributedString conversion success - length: \(attributedString.string.count)")
+        sagawaDebugLog("parseHTML() result preview: \(String(attributedString.string.prefix(200)))")
         return .success(attributedString.string)
     }
 }

--- a/Domain/APIProtcols/ApiClient.swift
+++ b/Domain/APIProtcols/ApiClient.swift
@@ -195,9 +195,7 @@ extension ApiClient {
 extension ApiClient {
     /// HTMLデータをパースしてAttributedStringに変換
     internal func parseHTML(from data: Data) -> Result<String, APIError> {
-        sagawaDebugLog("parseHTML() called - data size: \(data.count) bytes")
         guard !data.isEmpty else {
-            sagawaDebugLog("parseHTML() empty data received")
             return .failure(.emptyData)
         }
 
@@ -206,12 +204,9 @@ extension ApiClient {
             options: [.documentType: NSAttributedString.DocumentType.html],
             documentAttributes: nil
         ) else {
-            sagawaDebugLog("parseHTML() NSAttributedString conversion failed")
             return .failure(.htmlParseError("Failed to parse HTML content"))
         }
 
-        sagawaDebugLog("parseHTML() NSAttributedString conversion success - length: \(attributedString.string.count)")
-        sagawaDebugLog("parseHTML() result preview: \(String(attributedString.string.prefix(200)))")
         return .success(attributedString.string)
     }
 }

--- a/Domain/APIProtcols/ApiClient.swift
+++ b/Domain/APIProtcols/ApiClient.swift
@@ -3,7 +3,7 @@ import Foundation
 public final class ApiClient {
     public static let shared: ApiClient = ApiClient()
     public let basePath: String = "https://toi.kuronekoyamato.co.jp/cgi-bin"
-    public let sagawaBasePath: String = "https://k2k.sagawa-exp.co.jp/p/sagawa"
+    public let sagawaBasePath: String = "https://k2k.sagawa-exp.co.jp/p"
     public let japanPostBasePath: String = "https://trackings.post.japanpost.jp"
 
     /// APIクライアント設定
@@ -211,7 +211,7 @@ extension ApiClient {
     }
 }
 
-extension Dictionary where Key == String, Value == Int {
+extension Dictionary where Key == String, Value == String {
     init?<Request>(_ request: Request) where Request: RequestType & URLQueryEncodable {
         guard let data = try? JSONEncoder().encode(request),
               let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []),
@@ -219,23 +219,25 @@ extension Dictionary where Key == String, Value == Int {
             return nil
         }
 
-        // 各値を個別にIntに変換（NSNumber対応で大きな整数もサポート）
-        // nilの値はスキップ（POSTボディに含めない）
-        var result: [String: Int] = [:]
+        // 各値をStringに変換（Int/NSNumber/Stringに対応）
+        // nilの値はスキップ（POSTボディ/クエリパラメータに含めない）
+        var result: [String: String] = [:]
         for (key, value) in dict {
-            if let intValue = value as? Int {
-                result[key] = intValue
+            if let stringValue = value as? String {
+                result[key] = stringValue
+            } else if let intValue = value as? Int {
+                result[key] = String(intValue)
             } else if let nsNumber = value as? NSNumber {
-                result[key] = nsNumber.intValue
+                result[key] = nsNumber.stringValue
             }
-            // null（JSONのnull）の場合はスキップ
+            // NSNull（JSONのnull）の場合はスキップ
         }
         self = result
     }
 
     func equalEncode() -> String {
         return map { key, value in
-            return key + "=" + String(value)
+            return key + "=" + value
         }
         .joined(separator: "&")
     }

--- a/Domain/APIProtcols/DeliveryTrackingProtocol.swift
+++ b/Domain/APIProtcols/DeliveryTrackingProtocol.swift
@@ -48,8 +48,9 @@ public struct UnifiedDeliveryInfo: Codable, Equatable {
     }
 
     /// 最新のステータスを取得
+    /// statusList は古い順（chronological）で格納されるため .last が最新
     public var latestStatus: UnifiedDeliveryStatus? {
-        return statusList.first
+        return statusList.last
     }
 
     /// 配達完了かどうか

--- a/Domain/APIProtcols/RequestType.swift
+++ b/Domain/APIProtcols/RequestType.swift
@@ -7,9 +7,9 @@ public protocol RequestType {
 
 public extension URLRequest {
     init?<Request>(_ request: Request, baseURL: URL) where Request: RequestType & URLQueryEncodable {
-        guard let queryItems = [String: Int](request) else { return nil }
+        guard let queryItems = [String: String](request) else { return nil }
         let url = URL(string: "\(baseURL)/\(type(of: request).path)")!
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)!
 
         switch type(of: request).method {
         case .post:
@@ -18,6 +18,9 @@ public extension URLRequest {
             self.httpBody = queryData
             self.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         case .get:
+            if !queryItems.isEmpty {
+                components.queryItems = queryItems.map { URLQueryItem(name: $0.key, value: $0.value) }
+            }
             guard let urlWithQuery = components.url else { return nil }
             self.init(url: urlWithQuery)
         }

--- a/Domain/Endpoints/Sagawa.swift
+++ b/Domain/Endpoints/Sagawa.swift
@@ -1,16 +1,5 @@
 import Foundation
 
-// MARK: - Debug Logging Helper
-#if DEBUG
-@inline(__always)
-func sagawaDebugLog(_ message: @autoclosure () -> String) {
-    print("[SAGAWA_DEBUG] \(message())")
-}
-#else
-@inline(__always)
-func sagawaDebugLog(_ message: @autoclosure () -> String) {}
-#endif
-
 public struct SagawaRequest: RequestType, URLQueryEncodable {
     public static let path: String = "web/okurijosearch.do"
     public static let method: HTTPMethod = .get
@@ -88,7 +77,6 @@ private struct SagawaResponseParser {
     ///   行2: 日時 (例: "02/09 10:43")
     ///   行3: 営業所 (例: "野田営業所")
     func parse(trackingNumber: String, htmlContent: String) -> [Sagawa.TrackingInfo] {
-        sagawaDebugLog("SagawaResponseParser.parse() - START - trackingNumber: \(trackingNumber)")
 
         var statusList: [Sagawa.TrackingInfo.DeliveryStatus] = []
 
@@ -125,7 +113,6 @@ private struct SagawaResponseParser {
                         time: pendingTime,
                         location: location
                     )
-                    sagawaDebugLog("parse() - entry: \(entry.status) \(entry.date) \(entry.time ?? "") \(entry.location)")
                     statusList.append(entry)
                 }
                 pendingStatus = nil
@@ -136,8 +123,6 @@ private struct SagawaResponseParser {
                 break
             }
         }
-
-        sagawaDebugLog("SagawaResponseParser.parse() - COMPLETE - statusList count: \(statusList.count)")
 
         return [Sagawa.TrackingInfo(trackingNumber: trackingNumber, statusList: statusList)]
     }

--- a/Domain/Endpoints/Sagawa.swift
+++ b/Domain/Endpoints/Sagawa.swift
@@ -1,21 +1,17 @@
 import Foundation
 
 public struct SagawaRequest: RequestType, URLQueryEncodable {
-    public static let path: String = "web/okurijoinput.jsp"
-    public static let method: HTTPMethod = .post
-    
-    private let no: String
-    
+    public static let path: String = "web/okurijosearch.do"
+    public static let method: HTTPMethod = .get
+
+    private let okurijoNo: String
+
     public init(trackingNumber: String) {
-        self.no = trackingNumber
+        self.okurijoNo = trackingNumber
     }
-    
+
     var trackingNumber: String {
-        return no
-    }
-    
-    public func encode() -> [String: Any] {
-        return ["no": no]
+        return okurijoNo
     }
 }
 
@@ -59,57 +55,91 @@ extension Sagawa {
 }
 
 private struct SagawaResponseParser {
+    // 佐川急便のステータスキーワード
+    private static let statusKeywords = [
+        "集荷", "輸送中", "配達中", "配達完了", "持戻り", "不在",
+        "保管中", "配送中", "到着", "出荷"
+    ]
+
+    // 場所を示すキーワード
+    private static let locationKeywords = ["営業所", "センター", "店", "支店", "デポ"]
+
+    // 日付パターン: M/DD, MM/DD, M月D日, MM月DD日
+    private static let datePattern = #"(\d{1,2})/(\d{1,2})"#
+    private static let japaneseDatePattern = #"(\d{1,2})月(\d{1,2})日"#
+
+    // 時刻パターン: HH:MM
+    private static let timePattern = #"\d{1,2}:\d{2}"#
+
     func parse(trackingNumber: String, htmlContent: String) -> [Sagawa.TrackingInfo] {
         var statusList: [Sagawa.TrackingInfo.DeliveryStatus] = []
-        
+
         let lines = htmlContent.components(separatedBy: .newlines)
-        
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
         for line in lines {
-            if line.contains("配達状況") || line.contains("輸送状況") {
-                let statusInfo = parseStatusLine(line)
-                if let status = statusInfo.status, 
-                   let date = statusInfo.date,
-                   let location = statusInfo.location {
-                    let deliveryStatus = Sagawa.TrackingInfo.DeliveryStatus(
-                        status: status,
-                        date: date,
-                        time: statusInfo.time,
-                        location: location
-                    )
-                    statusList.append(deliveryStatus)
-                }
+            let parsed = parseStatusLine(line)
+            if let status = parsed.status,
+               let date = parsed.date,
+               let location = parsed.location {
+                let deliveryStatus = Sagawa.TrackingInfo.DeliveryStatus(
+                    status: status,
+                    date: date,
+                    time: parsed.time,
+                    location: location
+                )
+                statusList.append(deliveryStatus)
             }
         }
-        
+
         let trackingInfo = Sagawa.TrackingInfo(
             trackingNumber: trackingNumber,
             statusList: statusList
         )
-        
+
         return [trackingInfo]
     }
-    
+
     private func parseStatusLine(_ line: String) -> (status: String?, date: String?, time: String?, location: String?) {
-        let cleanLine = line.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-        let components = cleanLine.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-        
+        let components = line.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+
         var status: String?
         var date: String?
         var time: String?
         var location: String?
-        
+
         for component in components {
-            if component.contains("月") && component.contains("日") {
-                date = component.replacingOccurrences(of: "月", with: "/").replacingOccurrences(of: "日", with: "")
-            } else if component.contains(":") {
+            // 日付の検出（M月D日 形式）
+            if date == nil,
+               let match = component.range(of: Self.japaneseDatePattern, options: .regularExpression) {
+                let matched = String(component[match])
+                date = matched
+                    .replacingOccurrences(of: "月", with: "/")
+                    .replacingOccurrences(of: "日", with: "")
+            }
+            // 日付の検出（M/DD 形式）
+            else if date == nil,
+                    component.range(of: Self.datePattern, options: .regularExpression) != nil {
+                date = component
+            }
+            // 時刻の検出
+            else if time == nil,
+                    component.range(of: Self.timePattern, options: .regularExpression) != nil {
                 time = component
-            } else if component.contains("営業所") || component.contains("センター") || component.contains("店") {
+            }
+            // 場所の検出
+            else if location == nil,
+                    Self.locationKeywords.contains(where: { component.contains($0) }) {
                 location = component
-            } else if component.contains("集荷") || component.contains("配送") || component.contains("到着") || component.contains("完了") {
+            }
+            // ステータスの検出
+            else if status == nil,
+                    Self.statusKeywords.contains(where: { component.contains($0) }) {
                 status = component
             }
         }
-        
+
         return (status: status, date: date, time: time, location: location)
     }
 }

--- a/Domain/Endpoints/Sagawa.swift
+++ b/Domain/Endpoints/Sagawa.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+// MARK: - Debug Logging Helper
+#if DEBUG
+@inline(__always)
+func sagawaDebugLog(_ message: @autoclosure () -> String) {
+    print("[SAGAWA_DEBUG] \(message())")
+}
+#else
+@inline(__always)
+func sagawaDebugLog(_ message: @autoclosure () -> String) {}
+#endif
+
 public struct SagawaRequest: RequestType, URLQueryEncodable {
     public static let path: String = "web/okurijosearch.do"
     public static let method: HTTPMethod = .get
@@ -71,75 +82,113 @@ private struct SagawaResponseParser {
     // 時刻パターン: HH:MM
     private static let timePattern = #"\d{1,2}:\d{2}"#
 
+    /// 佐川のHTMLをパースして配達ステータスリストを生成
+    /// データは3行1セットで構成される:
+    ///   行1: ステータス (例: "↓集荷", "↓輸送中", "⇒配達完了")
+    ///   行2: 日時 (例: "02/09 10:43")
+    ///   行3: 営業所 (例: "野田営業所")
     func parse(trackingNumber: String, htmlContent: String) -> [Sagawa.TrackingInfo] {
+        sagawaDebugLog("SagawaResponseParser.parse() - START - trackingNumber: \(trackingNumber)")
+
         var statusList: [Sagawa.TrackingInfo.DeliveryStatus] = []
 
         let lines = htmlContent.components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
 
+        // State machine: collect status → date/time → location across lines
+        var pendingStatus: String?
+        var pendingDate: String?
+        var pendingTime: String?
+
         for line in lines {
-            let parsed = parseStatusLine(line)
-            if let status = parsed.status,
-               let date = parsed.date,
-               let location = parsed.location {
-                let deliveryStatus = Sagawa.TrackingInfo.DeliveryStatus(
-                    status: status,
-                    date: date,
-                    time: parsed.time,
-                    location: location
-                )
-                statusList.append(deliveryStatus)
+            let lineType = classifyLine(line)
+
+            switch lineType {
+            case .status(let status):
+                // New status found — flush any incomplete pending entry
+                pendingStatus = status
+                pendingDate = nil
+                pendingTime = nil
+
+            case .dateTime(let date, let time):
+                if pendingStatus != nil {
+                    pendingDate = date
+                    pendingTime = time
+                }
+
+            case .location(let location):
+                if let status = pendingStatus, let date = pendingDate {
+                    let entry = Sagawa.TrackingInfo.DeliveryStatus(
+                        status: status,
+                        date: date,
+                        time: pendingTime,
+                        location: location
+                    )
+                    sagawaDebugLog("parse() - entry: \(entry.status) \(entry.date) \(entry.time ?? "") \(entry.location)")
+                    statusList.append(entry)
+                }
+                pendingStatus = nil
+                pendingDate = nil
+                pendingTime = nil
+
+            case .other:
+                break
             }
         }
 
-        let trackingInfo = Sagawa.TrackingInfo(
-            trackingNumber: trackingNumber,
-            statusList: statusList
-        )
+        sagawaDebugLog("SagawaResponseParser.parse() - COMPLETE - statusList count: \(statusList.count)")
 
-        return [trackingInfo]
+        return [Sagawa.TrackingInfo(trackingNumber: trackingNumber, statusList: statusList)]
     }
 
-    private func parseStatusLine(_ line: String) -> (status: String?, date: String?, time: String?, location: String?) {
+    // MARK: - Line Classification
+
+    private enum LineType {
+        case status(String)
+        case dateTime(date: String, time: String?)
+        case location(String)
+        case other
+    }
+
+    private func classifyLine(_ line: String) -> LineType {
+        // ステータス判定: "↓集荷", "↓輸送中", "⇒配達完了" など
+        if Self.statusKeywords.contains(where: { line.contains($0) }) {
+            // 先頭の矢印記号を除去してステータス名を取得
+            let cleaned = line.replacingOccurrences(of: "↓", with: "")
+                              .replacingOccurrences(of: "⇒", with: "")
+                              .trimmingCharacters(in: .whitespaces)
+            return .status(cleaned)
+        }
+
+        // 日時判定: "02/09 10:43" or "02月09日"
         let components = line.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-
-        var status: String?
-        var date: String?
-        var time: String?
-        var location: String?
-
-        for component in components {
-            // 日付の検出（M月D日 形式）
-            if date == nil,
-               let match = component.range(of: Self.japaneseDatePattern, options: .regularExpression) {
-                let matched = String(component[match])
-                date = matched
+        if let firstComp = components.first {
+            // MM/DD形式
+            if firstComp.range(of: Self.datePattern, options: .regularExpression) != nil {
+                let time = components.count > 1 && components[1].range(of: Self.timePattern, options: .regularExpression) != nil
+                    ? components[1] : nil
+                return .dateTime(date: firstComp, time: time)
+            }
+            // M月D日形式
+            if let match = firstComp.range(of: Self.japaneseDatePattern, options: .regularExpression) {
+                let matched = String(firstComp[match])
+                let date = matched
                     .replacingOccurrences(of: "月", with: "/")
                     .replacingOccurrences(of: "日", with: "")
-            }
-            // 日付の検出（M/DD 形式）
-            else if date == nil,
-                    component.range(of: Self.datePattern, options: .regularExpression) != nil {
-                date = component
-            }
-            // 時刻の検出
-            else if time == nil,
-                    component.range(of: Self.timePattern, options: .regularExpression) != nil {
-                time = component
-            }
-            // 場所の検出
-            else if location == nil,
-                    Self.locationKeywords.contains(where: { component.contains($0) }) {
-                location = component
-            }
-            // ステータスの検出
-            else if status == nil,
-                    Self.statusKeywords.contains(where: { component.contains($0) }) {
-                status = component
+                let time = components.count > 1 && components[1].range(of: Self.timePattern, options: .regularExpression) != nil
+                    ? components[1] : nil
+                return .dateTime(date: date, time: time)
             }
         }
 
-        return (status: status, date: date, time: time, location: location)
+        // 場所判定: "野田営業所", "東関東中継センター" など
+        if Self.locationKeywords.contains(where: { line.contains($0) }) {
+            // TEL/FAX情報を除去して営業所名のみ取得
+            let name = components.first ?? line
+            return .location(name)
+        }
+
+        return .other
     }
 }

--- a/DomainTests/SagawaTests.swift
+++ b/DomainTests/SagawaTests.swift
@@ -8,15 +8,8 @@ class SagawaTests: XCTestCase {
         let trackingNumber = "1234567890"
         let request = SagawaRequest(trackingNumber: trackingNumber)
         XCTAssertEqual(request.trackingNumber, trackingNumber)
-        XCTAssertEqual(SagawaRequest.path, "web/okurijoinput.jsp")
-        XCTAssertEqual(SagawaRequest.method, .post)
-    }
-    
-    func test_SagawaRequest_encode() {
-        let trackingNumber = "1234567890"
-        let request = SagawaRequest(trackingNumber: trackingNumber)
-        let encoded = request.encode()
-        XCTAssertEqual(encoded["no"] as? String, trackingNumber)
+        XCTAssertEqual(SagawaRequest.path, "web/okurijosearch.do")
+        XCTAssertEqual(SagawaRequest.method, .get)
     }
     
     func test_Sagawa_initialization() {
@@ -47,18 +40,22 @@ class SagawaTests: XCTestCase {
     }
     
     func test_Sagawa_parsing_mock_response() {
-        let mockHTML = """
-        <html>
-        <body>
-        <div>配達状況 集荷完了 12月25日 14:30 東京営業所</div>
-        <div>輸送状況 配送中 12月26日 09:15 大阪営業所</div>
-        </body>
-        </html>
+        // NSAttributedString経由で変換された後のプレーンテキストを想定
+        let mockText = """
+        集荷 2/09 10:43 野田営業所
+        輸送中 2/09 12:03 東関東中継センター
         """
-        
-        let sagawa = Sagawa(trackingNumber: "1234567890", response: mockHTML)
+
+        let sagawa = Sagawa(trackingNumber: "1234567890", response: mockText)
         XCTAssertEqual(sagawa.trackingList.count, 1)
         XCTAssertEqual(sagawa.trackingList[0].trackingNumber, "1234567890")
+        XCTAssertEqual(sagawa.trackingList[0].statusList.count, 2)
+        XCTAssertEqual(sagawa.trackingList[0].statusList[0].status, "集荷")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[0].date, "2/09")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[0].time, "10:43")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[0].location, "野田営業所")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[1].status, "輸送中")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[1].location, "東関東中継センター")
     }
     
     func test_Sagawa_empty_response() {

--- a/DomainTests/SagawaTests.swift
+++ b/DomainTests/SagawaTests.swift
@@ -40,22 +40,32 @@ class SagawaTests: XCTestCase {
     }
     
     func test_Sagawa_parsing_mock_response() {
-        // NSAttributedString経由で変換された後のプレーンテキストを想定
+        // 佐川のHTML形式: 古いステータスが上、3行1セット（ステータス、日時、営業所）
+        // パーサーはそのまま古い順で格納する
         let mockText = """
-        集荷 2/09 10:43 野田営業所
-        輸送中 2/09 12:03 東関東中継センター
+        ↓集荷
+        2/09 10:43
+        野田営業所
+        ↓輸送中
+        2/09 12:03
+        東関東中継センター
         """
 
         let sagawa = Sagawa(trackingNumber: "1234567890", response: mockText)
         XCTAssertEqual(sagawa.trackingList.count, 1)
         XCTAssertEqual(sagawa.trackingList[0].trackingNumber, "1234567890")
         XCTAssertEqual(sagawa.trackingList[0].statusList.count, 2)
+        // 古い順: [0]=集荷（古い）, [1]=輸送中（新しい）
         XCTAssertEqual(sagawa.trackingList[0].statusList[0].status, "集荷")
         XCTAssertEqual(sagawa.trackingList[0].statusList[0].date, "2/09")
         XCTAssertEqual(sagawa.trackingList[0].statusList[0].time, "10:43")
         XCTAssertEqual(sagawa.trackingList[0].statusList[0].location, "野田営業所")
         XCTAssertEqual(sagawa.trackingList[0].statusList[1].status, "輸送中")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[1].date, "2/09")
+        XCTAssertEqual(sagawa.trackingList[0].statusList[1].time, "12:03")
         XCTAssertEqual(sagawa.trackingList[0].statusList[1].location, "東関東中継センター")
+        // アプリ規約: .last が最新ステータス
+        XCTAssertEqual(sagawa.trackingList[0].statusList.last?.status, "輸送中")
     }
     
     func test_Sagawa_empty_response() {


### PR DESCRIPTION
## Summary
- Implement end-to-end Sagawa (佐川急便) package tracking functionality
- Introduce multi-carrier architecture with parallel API fetching for Yamato and Sagawa
- Maintain backward compatibility with UserDefaults while adding carrier-aware persistent storage

## Changes (7 files, +299/-59)
- **DeliveryCarrier.swift**: Add `Codable` conformance
- **DeliveryItem.swift**: Add Sagawa initializer
- **DeliveryStatus.swift**: Add Sagawa status mapping + initializer
- **LocalDeliveryItems.swift**: New `StoredDeliveryItem`, dual-write strategy, automatic migration
- **AddListViewModel.swift**: Pass carrier info when adding tracking numbers, fix `[weak self]`
- **DeliveryListViewModel.swift**: Multi-carrier parallel fetching via `async let` + `TaskGroup`
- **BackgroundRefreshManager.swift**: Same multi-carrier support

## Architecture
- Yamato: Batch API (multiple tracking numbers in one request)
- Sagawa: Per-item fetch parallelized via `TaskGroup`
- Both carriers fetched concurrently using `async let`
- Dual-write to legacy `[Int]` format for Widget compatibility

## Test plan
- [ ] Add a Sagawa tracking number and verify delivery status displays correctly
- [ ] Verify existing Yamato tracking continues to work normally
- [ ] Confirm carrier info persists after app restart
- [ ] Verify Sagawa delivery info appears in Widget
- [ ] Confirm background refresh sends notifications for Sagawa updates