### PR TITLE
docs: Update README for v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ BlackCarWidget/            # WidgetKit home screen widget
 | UI | SwiftUI |
 | Reactive | Combine |
 | Testing | XCTest |
-| CI/CD | Fastlane |
 | Background (planned) | BGTaskScheduler |
 | Widget (planned) | WidgetKit |
 | Watch (planned) | WatchConnectivity, App Groups |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Available on the [App Store](https://apps.apple.com/jp/app/%E3%82%AF%E3%83%AD%E3
 ## Features
 
 - **Multi-Carrier Tracking** — Track packages from Yamato (ヤマト運輸), Sagawa (佐川急便), and Japan Post (日本郵便) in a unified interface
-- **Dark Mode** — Full support for both light and dark appearances
 - **Zero Dependencies** — Built entirely with Apple-native frameworks
 
 ### Coming Soon
@@ -22,6 +21,7 @@ Available on the [App Store](https://apps.apple.com/jp/app/%E3%82%AF%E3%83%AD%E3
 - **Home Screen Widget** — WidgetKit-powered widget for at-a-glance delivery status
 - **Background Refresh** — Automatic status updates via BGTaskScheduler at configurable intervals
 - **Push Notifications** — Alerts on status changes and delivery completion
+- **Dark Mode** — Full support for both light and dark appearances
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BlackCat - Package Delivery Tracker for iOS & Apple Watch
+# BlackCat - Package Delivery Tracker for iOS
 
-![](https://img.shields.io/badge/Platform-iOS%20%7C%20watchOS-blue.svg)
+![](https://img.shields.io/badge/Platform-iOS-blue.svg)
 ![](https://img.shields.io/badge/Xcode-26%2B-blue.svg)
 ![](https://img.shields.io/badge/Swift-5.0-orange.svg)
 ![](https://img.shields.io/badge/UI-SwiftUI-purple.svg)
@@ -13,12 +13,15 @@ Available on the [App Store](https://apps.apple.com/jp/app/%E3%82%AF%E3%83%AD%E3
 ## Features
 
 - **Multi-Carrier Tracking** — Track packages from Yamato (ヤマト運輸), Sagawa (佐川急便), and Japan Post (日本郵便) in a unified interface
-- **Apple Watch App** — View delivery status directly from your wrist with watch complications support
-- **Home Screen Widget** — Glance at your deliveries via a WidgetKit-powered widget
-- **Background Refresh** — Automatically fetches updated delivery status at configurable intervals (15 min – 2 hr)
-- **Push Notifications** — Get notified on status changes and delivery completion
 - **Dark Mode** — Full support for both light and dark appearances
 - **Zero Dependencies** — Built entirely with Apple-native frameworks
+
+### Coming Soon
+
+- **Apple Watch App** — View delivery status from your wrist with watch complications (code in place, under testing)
+- **Home Screen Widget** — WidgetKit-powered widget for at-a-glance delivery status
+- **Background Refresh** — Automatic status updates via BGTaskScheduler at configurable intervals
+- **Push Notifications** — Alerts on status changes and delivery completion
 
 ## Architecture
 
@@ -70,20 +73,18 @@ BlackCarWidget/            # WidgetKit home screen widget
 |---|---|
 | UI | SwiftUI |
 | Reactive | Combine |
-| Background | BGTaskScheduler |
-| Notifications | UserNotifications |
-| Widget | WidgetKit |
-| Watch Sync | WatchConnectivity |
-| Data Sharing | App Groups |
 | Testing | XCTest |
 | CI/CD | Fastlane |
+| Background (planned) | BGTaskScheduler |
+| Widget (planned) | WidgetKit |
+| Watch (planned) | WatchConnectivity, App Groups |
 
 ## Getting Started
 
 ### Requirements
 
 - Xcode 26 or later (recommended)
-- iOS / watchOS deployment target: 26.0
+- iOS deployment target: 26.0
 
 ### Build & Run
 

--- a/README.md
+++ b/README.md
@@ -1,76 +1,114 @@
-# BlackCat - 配達状況追跡アプリ
-![](https://img.shields.io/badge/Xcode-14.2%2B-blue.svg)
-![](https://img.shields.io/badge/iOS-16.0%2B-blue.svg)
-![](https://img.shields.io/badge/Swift-5.7%2B-orange.svg)
+# BlackCat - Package Delivery Tracker for iOS & Apple Watch
 
-Welcome to BlackCat's open source iOS app! Come on in, take your shoes off, stay a while - explore how BlackCat's native squad has built and continues to build the app.
-This is a 配達状況追跡アプリ's repository. Available at the [App Store](https://apps.apple.com/jp/app/%E3%82%AF%E3%83%AD%E3%83%8D%E3%82%B3%E9%85%8D%E9%81%94%E7%8A%B6%E6%B3%81/id1585504785).
+![](https://img.shields.io/badge/Platform-iOS%20%7C%20watchOS-blue.svg)
+![](https://img.shields.io/badge/Xcode-26%2B-blue.svg)
+![](https://img.shields.io/badge/Swift-5.0-orange.svg)
+![](https://img.shields.io/badge/UI-SwiftUI-purple.svg)
+![](https://img.shields.io/badge/License-MIT-green.svg)
 
-## What you can do with BlackCat
+A native iOS app for tracking package deliveries across major Japanese carriers — Yamato Transport, Sagawa Express, and Japan Post — all in one place. Built entirely with SwiftUI, Combine, and Apple-native frameworks. No third-party dependencies.
 
-Track your package deliveries from multiple Japanese carriers:
+Available on the [App Store](https://apps.apple.com/jp/app/%E3%82%AF%E3%83%AD%E3%83%8D%E3%82%B3%E9%85%8D%E9%81%94%E7%8A%B6%E6%B3%81/id1585504785).
 
-### Supported Carriers
+## Features
 
-| Carrier | Japanese Name | Tracking Number Format |
-|---------|---------------|------------------------|
-| Yamato Transport | ヤマト運輸 | 12 digits (starts with 1-4) |
-| Sagawa Express | 佐川急便 | 12 digits (starts with 5-7) |
-| Japan Post | 日本郵便 | 11-13 digits or international format (e.g., EA123456789JP) |
-
-### Key Features
-
-- **Multi-Carrier Support**: Track packages from Yamato, Sagawa, and Japan Post in one app
-- **Automatic Carrier Detection**: Just enter your tracking number - the app automatically identifies the carrier
-- **Real-time Status Updates**: Get the latest delivery status with a single tap
-- **Home Screen Widget**: Quick glance at your deliveries without opening the app
-- **Push Notifications**: Get notified when your package status changes
-- **Dark Mode Support**: Beautiful interface in both light and dark modes
-
-## Getting Started
-
-1. Install Xcode (Xcode 14.2 or later recommended)
-2. Clone this repository
-   ```bash
-   git clone https://github.com/tosh7/BlackCat.git
-   ```
-3. Open `BlackCat.xcodeproj` in Xcode
-4. Build and run on your device or simulator
+- **Multi-Carrier Tracking** — Track packages from Yamato (ヤマト運輸), Sagawa (佐川急便), and Japan Post (日本郵便) in a unified interface
+- **Apple Watch App** — View delivery status directly from your wrist with watch complications support
+- **Home Screen Widget** — Glance at your deliveries via a WidgetKit-powered widget
+- **Background Refresh** — Automatically fetches updated delivery status at configurable intervals (15 min – 2 hr)
+- **Push Notifications** — Get notified on status changes and delivery completion
+- **Dark Mode** — Full support for both light and dark appearances
+- **Zero Dependencies** — Built entirely with Apple-native frameworks
 
 ## Architecture
 
-The app follows MVVM architecture with Combine for reactive programming:
+MVVM with Combine for reactive data binding. The codebase is organized into four targets:
 
 ```
-BlackCat/
-├── Models/           # Data models (DeliveryCarrier, DeliveryItem, etc.)
-├── Scenes/           # Views and ViewModels
-│   ├── AddList/      # Package registration screen
-│   ├── DeliveryList/ # Main delivery list screen
-│   └── StateDetail/  # Delivery status detail screen
-├── Utils/            # Extensions and utilities
-└── CommonViews/      # Reusable UI components
+BlackCat/                  # Main iOS app
+├── Scenes/
+│   ├── Splash/            # Launch screen
+│   ├── DeliveryList/      # Main list of tracked packages
+│   ├── AddList/           # Register a new tracking number
+│   ├── StateDetail/       # Delivery status timeline
+│   ├── Settings/          # Background refresh, notifications, display
+│   ├── Onboarding/        # First-run experience
+│   └── Help/              # FAQ
+├── Models/                # DeliveryItem, DeliveryCarrier, DeliveryStatus
+├── Utils/                 # BackgroundRefreshManager, NotificationManager
+└── CommonViews/           # Reusable UI components
 
-Domain/
-├── APIProtocols/     # API client and error handling
-└── Endpoints/        # Request/Response models (Tneko, Sagawa)
+Domain/                    # Networking & API layer
+├── APIProtocols/          # Generic API client, error handling
+├── Endpoints/             # Carrier-specific request/response (Tneko, Sagawa, JapanPost)
+└── DomainTests/           # Unit tests per carrier + API error tests
+
+Shared/                    # Cross-target models
+├── SharedDeliveryItem     # Common delivery model
+├── SharedDataManager      # App Group data sync (iOS ↔ Widget ↔ Watch)
+└── WatchDeliveryData      # Lightweight Codable model for WatchConnectivity
+
+BlackCatWatch/             # watchOS companion app
+├── Views/                 # Watch-optimized list & detail views
+├── Complications/         # Watch face complications
+└── Utils/                 # WatchConnectivityManager
+
+BlackCarWidget/            # WidgetKit home screen widget
 ```
 
-## Dependencies
+## Supported Carriers
 
-No third-party libraries are used. All frameworks are provided by Apple:
-- SwiftUI
-- Combine
-- WidgetKit
-- UserNotifications
+| Carrier | Tracking Format | API |
+|---|---|---|
+| Yamato Transport (ヤマト運輸) | 12 digits | HTML scraping |
+| Sagawa Express (佐川急便) | 12 digits | HTML scraping |
+| Japan Post (日本郵便) | 11–13 digits / international (e.g. EA123456789JP) | REST API |
 
-## Changelog
+## Tech Stack
 
-See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.
+| Category | Technology |
+|---|---|
+| UI | SwiftUI |
+| Reactive | Combine |
+| Background | BGTaskScheduler |
+| Notifications | UserNotifications |
+| Widget | WidgetKit |
+| Watch Sync | WatchConnectivity |
+| Data Sharing | App Groups |
+| Testing | XCTest |
+| CI/CD | Fastlane |
+
+## Getting Started
+
+### Requirements
+
+- Xcode 26 or later (recommended)
+- iOS / watchOS deployment target: 26.0
+
+### Build & Run
+
+```bash
+git clone https://github.com/tosh7/BlackCat.git
+cd BlackCat
+open BlackCat.xcodeproj
+```
+
+Select the `BlackCat` scheme and run on a simulator or device.
+
+## Testing
+
+```bash
+xcodebuild test -project BlackCat.xcodeproj -scheme BlackCat -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Tests cover:
+- Carrier API parsing (Tneko, Sagawa, Japan Post)
+- ViewModel logic (DeliveryList, AddList, StateDetail)
+- API error handling and HTTP method routing
 
 ## License
 
-MIT License
+[MIT](license)
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- Rewrite README in English for international readability
- Reflect current project state: multi-carrier tracking (Yamato, Sagawa, Japan Post), MVVM + Combine architecture, zero third-party dependencies
- Move unfinished features (Apple Watch, Widget, Background Refresh, Push Notifications, Dark Mode) to Coming Soon section
- Update requirements to Xcode 26+
- Add architecture diagram, tech stack table, supported carriers table, and testing instructions