### PR TITLE
ci: Add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Test
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
+
+      - name: Boot Simulator
+        run: |
+          DEVICE_ID=$(xcrun simctl create "CI iPhone" "iPhone 16" "iOS26")
+          xcrun simctl boot "$DEVICE_ID"
+          echo "DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
+
+      - name: Run BlackCatTests
+        run: |
+          xcodebuild test \
+            -scheme BlackCat \
+            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -resultBundlePath TestResults/BlackCatTests \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Run DomainTests
+        run: |
+          xcodebuild test \
+            -scheme DomainTests \
+            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -resultBundlePath TestResults/DomainTests \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Shutdown Simulator
+        if: always()
+        run: xcrun simctl shutdown "$DEVICE_ID" || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           xcodebuild test \
             -scheme BlackCat \
-            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -destination "platform=iOS Simulator,name=iPhone 16e" \
             -resultBundlePath TestResults/BlackCatTests \
             CODE_SIGNING_ALLOWED=NO
 
@@ -29,6 +29,6 @@ jobs:
         run: |
           xcodebuild test \
             -scheme DomainTests \
-            -destination "platform=iOS Simulator,name=iPhone 16" \
+            -destination "platform=iOS Simulator,name=iPhone 16e" \
             -resultBundlePath TestResults/DomainTests \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [develop, main]
   pull_request:
-    branches: [develop, main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,25 +12,16 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
-
-      - name: Boot Simulator
-        run: |
-          DEVICE_ID=$(xcrun simctl create "CI iPhone" "iPhone 16" "iOS26")
-          xcrun simctl boot "$DEVICE_ID"
-          echo "DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
 
       - name: Run BlackCatTests
         run: |
           xcodebuild test \
             -scheme BlackCat \
-            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -resultBundlePath TestResults/BlackCatTests \
             CODE_SIGNING_ALLOWED=NO
 
@@ -38,10 +29,6 @@ jobs:
         run: |
           xcodebuild test \
             -scheme DomainTests \
-            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -destination "platform=iOS Simulator,name=iPhone 16" \
             -resultBundlePath TestResults/DomainTests \
             CODE_SIGNING_ALLOWED=NO
-
-      - name: Shutdown Simulator
-        if: always()
-        run: xcrun simctl shutdown "$DEVICE_ID" || true


### PR DESCRIPTION
## Summary
- Add `.github/workflows/test.yml` to run tests on CI
- Targets `macos-15` runner with Xcode 26 (will pass once Xcode 26 is available on runners)
- Runs both `BlackCatTests` and `DomainTests` schemes on iPhone 16 (iOS 26) simulator
- Code signing disabled for CI environment

## Test plan
- [x] YAML syntax is valid
- [ ] Workflow triggers on PR to develop (verify after PR creation)
- [ ] Tests will pass once Xcode 26 is available on GitHub-hosted runners