### PR TITLE
fix: Xcode 26 extension init compilation errors

### DIFF
--- a/BlackCat/Models/DeliveryItem.swift
+++ b/BlackCat/Models/DeliveryItem.swift
@@ -21,22 +21,26 @@ struct DeliveryItem: Identifiable {
 
 extension DeliveryItem {
     init(deliveryList: Tneko.DeliveryList, carrier: DeliveryCarrier = .yamato) {
-        self.deliveryID = deliveryList.deliveryID
-        self.statusList = deliveryList.statusList.map {
-            DeliveryStatus(deliveryStatus: $0)
-        }
-        self.carrier = carrier
-        self.registeredDate = Date()
+        self.init(
+            deliveryID: deliveryList.deliveryID,
+            statusList: deliveryList.statusList.map {
+                DeliveryStatus(deliveryStatus: $0)
+            },
+            carrier: carrier,
+            registeredDate: Date()
+        )
     }
 }
 
 extension DeliveryItem {
     init(trackingInfo: Sagawa.TrackingInfo, carrier: DeliveryCarrier = .sagawa) {
-        self.deliveryID = Int(trackingInfo.trackingNumber) ?? 0
-        self.statusList = trackingInfo.statusList.map {
-            DeliveryStatus(sagawaStatus: $0)
-        }
-        self.carrier = carrier
-        self.registeredDate = Date()
+        self.init(
+            deliveryID: Int(trackingInfo.trackingNumber) ?? 0,
+            statusList: trackingInfo.statusList.map {
+                DeliveryStatus(sagawaStatus: $0)
+            },
+            carrier: carrier,
+            registeredDate: Date()
+        )
     }
 }

--- a/BlackCat/Models/DeliveryStatus.swift
+++ b/BlackCat/Models/DeliveryStatus.swift
@@ -72,18 +72,22 @@ struct DeliveryStatus: Identifiable {
 
 extension DeliveryStatus {
     init(deliveryStatus: Tneko.DeliveryList.DeliveryStatus) {
-        self.status = deliveryStatus.status
-        self.date = deliveryStatus.date
-        self.time = deliveryStatus.time
-        self.shopName = deliveryStatus.shopName
+        self.init(
+            status: deliveryStatus.status,
+            date: deliveryStatus.date,
+            time: deliveryStatus.time,
+            shopName: deliveryStatus.shopName
+        )
     }
 }
 
 extension DeliveryStatus {
     init(sagawaStatus: Sagawa.TrackingInfo.DeliveryStatus) {
-        self.status = sagawaStatus.status
-        self.date = sagawaStatus.date
-        self.time = sagawaStatus.time
-        self.shopName = sagawaStatus.location
+        self.init(
+            status: sagawaStatus.status,
+            date: sagawaStatus.date,
+            time: sagawaStatus.time,
+            shopName: sagawaStatus.location
+        )
     }
 }

--- a/BlackCat/Models/TnekoClient.swift
+++ b/BlackCat/Models/TnekoClient.swift
@@ -8,8 +8,8 @@ struct TnekoClient: Identifiable {
 
 extension TnekoClient {
     init(tneko: Tneko, carrier: DeliveryCarrier = .yamato) {
-        self.deliveryList = tneko.deliveryList.map {
+        self.init(deliveryList: tneko.deliveryList.map {
             DeliveryItem(deliveryList: $0, carrier: carrier)
-        }
+        })
     }
 }

--- a/BlackCatTests/BlackCatTests.swift
+++ b/BlackCatTests/BlackCatTests.swift
@@ -19,20 +19,20 @@ final class BlackCatTests: XCTestCase {
     // MARK: - DeliveryItem Tests
 
     func test_deliveryItem_hasUniqueId() throws {
-        let item1 = DeliveryItem(deliveryID: 123456789012, statusList: [])
-        let item2 = DeliveryItem(deliveryID: 123456789012, statusList: [])
+        let item1 = makeDeliveryItem(deliveryID: 123456789012, statusList: [])
+        let item2 = makeDeliveryItem(deliveryID: 123456789012, statusList: [])
         XCTAssertNotEqual(item1.id, item2.id)
     }
 
     func test_deliveryItem_storesDeliveryID() throws {
         let deliveryID = 123456789012
-        let item = DeliveryItem(deliveryID: deliveryID, statusList: [])
+        let item = makeDeliveryItem(deliveryID: deliveryID, statusList: [])
         XCTAssertEqual(item.deliveryID, deliveryID)
     }
 
     func test_deliveryItem_storesStatusList() throws {
         let status = DeliveryStatus(status: "delivered", date: "01/01", time: "10:00", shopName: "TestShop")
-        let item = DeliveryItem(deliveryID: 123456789012, statusList: [status])
+        let item = makeDeliveryItem(deliveryID: 123456789012, statusList: [status])
         XCTAssertEqual(item.statusList.count, 1)
         XCTAssertEqual(item.statusList[0].status, "delivered")
     }
@@ -56,14 +56,14 @@ final class BlackCatTests: XCTestCase {
     // MARK: - TnekoClient Tests
 
     func test_tnekoClient_hasUniqueId() throws {
-        let client1 = TnekoClient(deliveryList: [])
-        let client2 = TnekoClient(deliveryList: [])
+        let client1 = makeTnekoClient(deliveryList: [])
+        let client2 = makeTnekoClient(deliveryList: [])
         XCTAssertNotEqual(client1.id, client2.id)
     }
 
     func test_tnekoClient_storesDeliveryList() throws {
-        let item = DeliveryItem(deliveryID: 123456789012, statusList: [])
-        let client = TnekoClient(deliveryList: [item])
+        let item = makeDeliveryItem(deliveryID: 123456789012, statusList: [])
+        let client = makeTnekoClient(deliveryList: [item])
         XCTAssertEqual(client.deliveryList.count, 1)
     }
 
@@ -96,19 +96,17 @@ final class BlackCatTests: XCTestCase {
     }
 }
 
-// MARK: - DeliveryItem Extension for Testing
+// MARK: - Test Helpers
 
-extension DeliveryItem {
-    init(deliveryID: Int, statusList: [DeliveryStatus]) {
-        self.deliveryID = deliveryID
-        self.statusList = statusList
-    }
+private func makeDeliveryItem(deliveryID: Int, statusList: [DeliveryStatus]) -> DeliveryItem {
+    DeliveryItem(
+        deliveryID: deliveryID,
+        statusList: statusList,
+        carrier: .yamato,
+        registeredDate: Date()
+    )
 }
 
-// MARK: - TnekoClient Extension for Testing
-
-extension TnekoClient {
-    init(deliveryList: [DeliveryItem]) {
-        self.deliveryList = deliveryList
-    }
+private func makeTnekoClient(deliveryList: [DeliveryItem]) -> TnekoClient {
+    TnekoClient(deliveryList: deliveryList)
 }


### PR DESCRIPTION
## Summary
- Fix compilation errors in Xcode 26 (Swift 6) where `let` properties with default values cannot be directly assigned in extension initializers
- Use `self.init(...)` delegation to memberwise initializers in `DeliveryItem`, `DeliveryStatus`, and `TnekoClient`
- Replace test helper extensions with factory functions in `BlackCatTests`

## Changed files
- `BlackCat/Models/DeliveryItem.swift` — delegate extension inits via `self.init(...)`
- `BlackCat/Models/DeliveryStatus.swift` — delegate extension inits via `self.init(...)`
- `BlackCat/Models/TnekoClient.swift` — delegate extension init via `self.init(...)`
- `BlackCatTests/BlackCatTests.swift` — replace extension inits with `makeDeliveryItem`/`makeTnekoClient` factory functions

## Test plan
- [ ] CI passes on macos-26 with Xcode 26.2